### PR TITLE
Create June 2022 meeting notes

### DIFF
--- a/notes/2022-06-21.md
+++ b/notes/2022-06-21.md
@@ -45,7 +45,7 @@ Testing notebooks plan
      - Get a ST simple notebook for the initial test rendered in NB convert
      - Erik - figure out how to render https://spacetelescope.github.io/notebooks/notebooks/DrizzlePac/optimize_image_sampling/optimize_image_sampling.html even if it disappears from ST
      - Tony - figure out if the NB convert machinery and Doc Utils have overlap
-     - Take notebooks and split into 2 testing realms (?)
+     - Take notebooks and split into 2 testing realms
 4. Prep for development
      - Tony - create a notebook that we can develop to (lorenz?)
      - Tony & Patrick  meet to do tech setup

--- a/notes/2022-06-21.md
+++ b/notes/2022-06-21.md
@@ -1,0 +1,53 @@
+# Astronomy Notebooks For All - June 21, 2022 notes
+
+## Agenda
+
+- Testing candidates discussion / planning
+     - Everything is going in a google drive folder. Can we check that we all have access?
+          - Patrick: I only have read access to the folder
+          - Isabela: this should be fixed! I added another email for you, Patrick.
+     - [List of possible notebooks for testing](https://docs.google.com/spreadsheets/d/1coMdDVX5OfHErpiHtUOuI3YK39ASAdx4NXqreNwQBuA/edit?usp=sharing). Isabela is looking for some guidance to narrow this list down. Do any of you have preferred notebooks?
+     - Sounds like we’re leaning towards a smaller notebook, like [the template notebook](https://github.com/spacetelescope/style-guides/blob/master/guides/jupyter-notebooks.md) or a JDAT or JWebbinar notebook.
+     - Current draft testing script. Isabela is looking for feedback on the scope and tasks covered in this draft.
+     - Since we all have possible testers, we can add them to this spreadsheet so we are ready to schedule.
+     - Blockers: **1.** What platform are we testing on/what is STScI’s nbviewer? **2.** We need to narrow down which notebook(s?) we want to test with. **3.** What STScI policies do we need to be sure to abide by for research?
+- GitHub repository
+     - Public meeting notes / agenda on GitHub?
+          - +1 to public meeting notes from Isabela
+     - Tracking issues workflow
+- Event planning update
+- Follow up from last meeting: standards/scoping for the entire grant.
+     - WCAG, U.S. laws, ACT-rules, something else, none of the above.
+
+## Work Plan
+
+1. Short term start testing with jinja template
+2. Write a specifications document
+3. Set up infrastructure to edit sphinx
+4. Then work on testing doc utils
+
+Testing notebooks plan
+1. Test navigation
+2. Test content
+
+## Tasks
+
+1. Decide which notebook to use for first test
+     - Isabela- Find a short simple initial test notebook, look through rendered notebooks and see if one is simple enough
+          - “older” version: https://github.com/spacetelescope/notebooks rendered to https://spacetelescope.github.io/notebooks/
+          - “newest” version: https://github.com/spacetelescope/jdat_notebooks rendered to https://spacetelescope.github.io/jdat_notebooks/intro.html
+          - Example to look at as a “counter-point”: https://spacetelescope.github.io/notebooks/notebooks/DrizzlePac/optimize_image_sampling/optimize_image_sampling.html 
+     - Erik- If none are simple enough, create a rendered version of the template notebook in our repo or an easy render 
+2.  Complete script for first test
+     - Jenn & Isabela meet to continue polishing script
+     - Schedule a practice run with Patrick using a screen reader (when script is complete)
+3. Prep tech for tests
+     - Get a ST simple notebook for the initial test rendered in NB convert
+     - Erik - figure out how to render https://spacetelescope.github.io/notebooks/notebooks/DrizzlePac/optimize_image_sampling/optimize_image_sampling.html even if it disappears from ST
+     - Tony - figure out if the NB convert machinery and Doc Utils have overlap
+     - Take notebooks and split into 2 testing realms (?)
+4. Prep for development
+     - Tony - create a notebook that we can develop to (lorenz?)
+     - Tony & Patrick  meet to do tech setup
+5. Future
+     - Erik - provide some extreme notebooks for future tests


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR
- Creates a new `notes` directory for this and future notekeeping
- Adds the June 2022 notes as a markdown file

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. 🌻 