### PR TITLE
Create July 2022 meeting notes

### DIFF
--- a/notes/2022-07-19.md
+++ b/notes/2022-07-19.md
@@ -1,0 +1,48 @@
+# Astronomy Notebooks For All - July 19, 2022 notes
+
+## Agenda
+
+- The [Inclusive Components book](https://inclusive-components.design/) was found in the wild offices of STScI! 
+- Event planning update (moved from last month)
+  - This is not high-priority at the moment because we need to spend time to get the other areas up and running.
+  - The only thing we may want to put first is getting a location reserved because it is difficult to do last-minute.
+- User testing update
+  - Jenn is trying to figure out how to pay participants
+       - HR blockers and mystery timelines are a concern.
+       - Is this a blocker for scheduling testers, or do we want to schedule while this is still in flux?
+       - Conclusion: we are looking for a timeline for payment to tell testers before outreach. We need to get a sense for the situation so we can plan accordingly. 
+       - Do testers need to sign any forms (consent forms, payment forms)?
+  - Thanks to Erik for [the notebook](https://eteq.github.io/notebooks-for-all/14jun22_stsci_example_notebook.html)!
+  - Recruiting timeline?
+    - We have a list of people to outreach too and a template with the beginning info they need.
+    - This will be temporarily blocked by the payment timeline questions, but things are ready to deployed when that is unblocked.
+  - Finalizing testing script
+  - Schedule Practice test with Patrick (post-August 5)
+  - Browsers for test
+    -  Lack of support for Edge and IE
+    -  More support for Firefox and Chrome, but safari can work
+    -  Ask “what is your default browser” when recruiting to know beforehand and plan accordingly
+-  Tony and Patrick report! Technical stuff
+   - We met to set up and explore the existing infrastructure we will be working with.
+   - Took note of some beginning notebook semantics and mis/alignments. Main, section, article HTML semantics.
+   - Future conversation: semantics to use
+   - Adding static, automated accessibility tests is something needed, but currently nontrivial. This will help us measure changes and help with reporting.
+      - What do we mean by “tests” in this case? Automated tests, the user testing, something else?
+- Notebooks for all repo
+  - Renamed master to main
+  - Branch protection
+  - Conventions for cells, cell, output section tags
+  - How do we want to use this repo? How does it archive our work so we can reproduce this issues and demonstrate the changes?
+   - To store notes, to store and render the notebooks we will use for usability tests, to store usability test resources, to hold automated testing and CI, to provide a space for reproducing test results by test round. This is subject for further discussion.
+
+## Work Plan
+
+## Tasks
+
+- Jenn and Isabela: Schedule a practice run with Patrick using a screen reader (when script is complete) (post-August 5)
+- Jenn: Test participant payment
+- Isabela: Generic test consent form
+- Jenn: does HR have a consent form needed for this kind of test/contracting?
+- Erik: make a PR for repo organization so we know where people want things (so we stop confusing scripts and scripts and tests and tests 😆)
+- Isabela: make another pass at editing the user testing script based on testing notebook
+- Event date and room reservation by end of August


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR
- Adds the July 2022 notes as a markdown file

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. 🌻 