### PR TITLE
Create September 2022 meeting notes

### DIFF
--- a/notes/2022-09-13.md
+++ b/notes/2022-09-13.md
@@ -1,0 +1,26 @@
+# Astronomy Notebooks For All - September 13, 2022 notes
+
+## Agenda
+
+- General project updates
+    - Figuring out development time and delgation. There are a few options available to keep us making fixes. User testing can proceed either way.
+- Event planning update?
+    - Scheduling a venue is still on the to-do list! No updates.
+- User testing updates
+    - First round of usability tests are done! Pulled out takeaways and Jenn and Isabela split [writing them up on the repo](https://github.com/Iota-School/notebooks-for-all/issues?q=is%3Aissue+is%3Aopen+label%3A%22test+1%3A+navigation%22). The write ups are a work in progress.
+    - We have interest from another possible tester! Do we want to run the same test with a new person, or save them to the next round?
+        - Save for next round
+    - Aim to run a test in November? This is tight (would need to be first two weeks of November).
+        - Prepping the new notebook is not a problem in this timeline with the current nbconvert and GitHub pages infrastructure.
+        - Getting to the JupyterBook setup should be a priority, but there is still a lot of moving parts. It doesn’t sound stable enough for this end-of-year testing timeline.
+    - Coming soon: test 1 resources that can be public!
+- Repo/infrastructure updates
+- Next steps are working on issues surfaced by the testing.
+- Fix CI work
+- Maybe run an importance–difficulty matrix workshop to help us prioritize where to start
+    - Where can we intervene?
+    - Which require design before development?
+    - Which issues are upstream?
+    - Which prevented participants from completing tasks versus which did not?
+    - Highest impact vs difficulty
+    - High level output that we share with a wider group


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR

- Adds the September 2022 notes as a markdown file

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. 🌻
