### PR TITLE
Create October 2022 meeting notes

### DIFF
--- a/notes/2022-10-11.md
+++ b/notes/2022-10-11.md
@@ -1,0 +1,32 @@
+# Astronomy Notebooks For All - October 11, 2022 notes
+
+## Agenda
+
+- License for repo! 
+    - Software: BSD3 or Apache
+    - Content: CC-BY
+    - How do we reflect this in our repo that has mixed content?
+        - Pick one of the two and just apply it to all (ie. count user research as software)
+        - Create a license file with both licenses in them and clarifying what applies to what
+        - Keeping all user research in its own directory and having the relevant license there. Then have a license for the rest of the repo.
+- Event planning updates
+    - Chose venue
+    -   Dates: 
+         - March 10th: Accessibility Hackathon (remote)
+              - Remote or hybrid? Concern that hybrid is 1.5–1.8 times the work and we don’t have a team for that.
+         - April 13th: Day of Accessibility (in-person)
+- User testing updates
+    - Planning for second round of tests. We need a notebook to write the script.
+    - [Work in progress PR for test 1: navigation results](https://github.com/Iota-School/notebooks-for-all/pull/26) to be public
+- Development updates
+    - Setting up and understanding the infrastructure- Patrick and Tony meeting about doit
+    - Making changes in a code-formatting style—adding landmarks and replacing nonspecific tags (like divs) with more specific ones. “nbconvert exporter” via beautiful soup
+        - This is an experiment to try what is or isn’t working and not intended as the long term solution.
+        - Potential as a toggle versus tests, ie. A B testing
+        - Reconvene on this testing approach in early November to see if we can integrate it
+- Erik at NumFocus summit - accessibility conversation came up and he pointed them to this repo
+    - Keep our radars open to other chances to let people know about this work
+- Meeting notes? Are we okay if Isabela merges all notes PRs? Yes!
+- Should we [create labels for where the fix needs to end up](https://github.com/Iota-School/notebooks-for-all/issues/25)? Yep! Let’s try and we can always follow up.
+
+


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR

- Adds the October 2022 notes as a markdown file

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. 🌻