### PR TITLE
Add License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+3-Clause BSD License
+
+Copyright 2022 Notebooks For All Contributors
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ As part of this initiative, STScI will collaborate with STEM- and accessibility-
 [A Curated List of STScI notebooks](https://github.com/spacetelescope/notebooks)  
 [Accessibility Analysis of Jupyter Notebook HTML Output](https://www.youtube.com/watch?v=KsUF_HjA97U&t=253s)  
 
+## License
+
+Because this repository hosts mixed content types, we have decided to apply different licenses to the content type they are most suited for. All of the repository except the `[user-tests](user-tests)` directory are under a [3-Clause BSD license](LICENSE). All content in the `[user-tests](user-tests)` directory is under a [CC-BY license](https://creativecommons.org/licenses/by/4.0/).
 
 
 


### PR DESCRIPTION
As we've been adding more content, lots that is intended for reuse, we've had some discussions around what license suits this repo. I'm opening this PR based on those discussions (most recently recorded in [the October 2022 meeting notes](https://github.com/Iota-School/notebooks-for-all/pull/27/files)). This PR:
- Adds a `LICENSE` file to the root of the repository. It's a BSD-3 license with contributors as the copyright holders.
- Adds a Licenses section to the bottom of the root `README.md` to describe our reasoning for (long term) adding two licenses. Note that it references a directory #26 adds that does not yet exist in the main branch. I'm open to feedback if we want to handle that parallel adding differently.

Review and other feedback are very welcome! Thanks in advance for giving this a once-over.