### PR TITLE
Create January 2023 meeting notes

### DIFF
--- a/notes/2023-01-03.md
+++ b/notes/2023-01-03.md
@@ -1,0 +1,33 @@
+# Astronomy Notebooks For All - November 8, 2022 notes
+
+## Updates 
+
+- Work on [PR for adding the ability to tab through cells](https://github.com/Iota-School/notebooks-for-all/pull/34).
+    - aria labels as only appropriate for interactive areas, but we are working in the rendered notebook. Example: markdown cells are interactive in an editable notebook, but non interactive in the rendered notebook.
+    - code/code cells could still be considered interactive because they invite people to investigate/copy and paste to work with the source of the output on their own. Tony argues this is the implication of code cells even in a rendered notebook. Maybe code cells and markdown cells should not be treated the same.
+    - Discussed about how to move forward with the ability to label cells (ie. not just navigate to them, but also know before reading what cell type it is). Is there potential to test this? 
+- Rendering dataframes for screen readers with pandas demo?
+    - [Source](https://tonyfast.github.io/tonyfast/xxiii/2023-01-02-accessible-dataframes-basic-indexes.html)
+    - Exploring a combo of best practices and possible fixes for tables.
+- Configuration file for a notebook set up. To help us test changes/settings to a notebook in a trackable and reproducible way. This can help with future testing, especially A/B testing.
+    - [Notebooks already configured (for perusal)](https://iota-school.github.io/notebooks-for-all/)
+    - All these configurations have all the fixes (all fix flags on)
+- Contrast fixes (?) 
+    - One of the commits in https://github.com/Iota-School/notebooks-for-all/pull/34
+    - Borrowing JupyterLab styles
+    - Need to review and mark off the issue(s) if relevant. We need to find where that is reviewed.
+- Another two user tests in two weeks.
+    - What are we testing? Probably test 2 script.
+    - Can we include these changes we have available in the configuration file? We think yes.
+- User testing
+    - Coordination for next tests.
+    - Jenn started test 2 write up. 
+
+## Next Steps
+
+- Everyone to review existing issues and add any notes. Collect ones for triage at next meeting.
+- Jenn and Isabela to write up test 2 results bit by bit.
+- Tony to give us a list of changes made/issues resolved (if relevant) (may be in config file)
+- Jenn and Isabela to prepare for next usability tests. Clarify what we are testing and when. Right now it seems test script 2 on the same notebook with tabbable cells.
+- Tony to re-add tabbing by cell capability (for user testing).
+- Follow up on event planning things.


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR

-  Adds the Janurary 2023 notes as a markdown file

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. Happy new year! 🌻 
