### PR TITLE
 Create January 2023 meeting notes (Again! Because we met twice in January.)

### DIFF
--- a/notes/2023-01-03.md
+++ b/notes/2023-01-03.md
@@ -1,4 +1,4 @@
-# Astronomy Notebooks For All - November 8, 2022 notes
+# Astronomy Notebooks For All - January 3, 2023 notes
 
 ## Updates 
 

--- a/notes/2023-01-31.md
+++ b/notes/2023-01-31.md
@@ -1,0 +1,67 @@
+# Astronomy Notebooks For All - January 31, 2023 notes
+
+## Events
+
+- Started advertising (Remote)
+- General schedule in place (Remote). About 2 hours.
+- Break out rooms and multiple moderators
+- What is the outcome for the attendee
+    - High level notebook accessibility. Test practices. Challenges in the space. Raise Awareness.
+    - Helping/teaching folks about headers, alt text, tables
+    - Is this author-focused? Not exclusively, but we seem to have most resources focused on that. We can invite more broadly.
+- Cut off date for sign up? No, because it’s remote. But we need to make sure that the link is available no matter when people sign up.
+- Is there a connection between the two events? Thematically they are related, but not more than that.
+
+To do:
+- Make author tips draft
+- Write reminder email (for sending to people who are signed up)
+- Promote the event link
+- Blog post about the event after
+
+## Usability test updates/reports
+
+Usability test updates/reports:
+- Two more tests run off the test 2 script in modified notebooks in January
+- This notebook had enhanced contrast and the ability to tab through cells.
+- Possible next step: set up several notebooks with different fixes (or different versions of the same fix) and write questions for participants to do asynchronously. This way we can compare fixes and see what is working for who so that we decide what to incorporate in the end.
+
+Possible notebook fixes to test:
+- contenteditable=”false” to all cells.
+- Modified landmark approach
+- Something that allows jumping to “editable” areas (may be contenteditable, may be something else)
+
+To do:
+- Write ticket to use E to jump to cells  https://www.accessibility-developer-guide.com/knowledge/screen-readers/desktop/browse-focus-modes/
+- Async usability testing to compare different cell navigation
+- Ways of communicating
+
+
+## Timeline for the rest of the grant
+
+- End of grant: April, but can request extension. Especially if no cost.
+- Event 1 (remote): March 10
+- Event 2 (in-person): April 13
+
+
+## Resources to make
+
+- Test 2 wrap up report
+- Test 2 issues
+- Publish a blog post on the [Jupyter Blog](https://blog.jupyter.org/)
+- Talk at JupyterCon (pending acceptance)
+- Poster from JupyterCon (pending acceptance)
+- PyData Seattle talk (pending acceptance)
+- Space Telescope blog (Which blog?)
+- Also maybe the ST twitter?
+- Upstream notebook fixes to STScI - which are reasonable to include? (issue to come)
+- Notebook authoring best practices document
+- Upstream authoring practices fixes (ie. update the STScI copyediting/review guide)
+- Can this be a Jupyter best practice training event?
+- DDRF report
+- Next questions we want to investigate (next steps), questions we didn’t get to (clarify the loose ends we still have so we remember in the future)
+
+
+## Cool stuff
+
+- [Neurodiversity Design System](https://neurodiversity.design/)
+- [Bridging Journalism’s Data Viz Accessibility Gap](https://reutersinstitute.politics.ox.ac.uk/sites/default/files/2023-01/RISJ%20Fellows%20Paper_MT22_JohnyC_FINAL%202.pdf)


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR

- Adds the January 31 2023 notes as a markdown file
- Corrects the title of the January 3 2023 meeting notes

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. 🌻