### PR TITLE
Create March 2023 meeting notes

### DIFF
--- a/notes/2023-03-28.md
+++ b/notes/2023-03-28.md
@@ -1,0 +1,34 @@
+# Astronomy Notebooks For All - March 28, 2023 notes
+
+## Latest notebook experiment demo (Tony)
+
+- [Link to experimental notebook](https://iota-school.github.io/notebooks-for-all/branch/table-form/exports/html/Imaging_Sky_Background_Estimation-table-default.html)
+- Cells are all in a table. Cells are actually table cells.
+- Notebook is a form?
+- Skiplink and table of contents?
+- [related notebooks-for-all #49 PR](https://github.com/Iota-School/notebooks-for-all/pull/49)
+- Navigating between cells is possible with arrow keys
+- Question: is this testable in our timeline? There is definitely interest.
+    - Usability test? Asynchronous? Fifteen minutes and a Likert scale?
+    - We will follow up on this possibility post-event. We want to do it,  but we are being cautious of spreading resources.
+    - Interest in reusing the navigation tasks we used in other tests to compare experiences.
+- Interest in splitting the repo for development and resource work. They move at different paces and seem like they may be destabilizing each other as a result.
+
+## Other updates
+
+- Patrick is giving a talk! (Isabela doesn’t have a link)
+- Isabela is putting document writing and polishing what’s there at a priority before the event.
+
+## Events
+- Day of Accessibility is coming up!
+- Going through our collaborative event task agenda.
+- Assign things to people where relevant so they can prepare. But we will also be on call.
+- Looking for additional volunteers, especially for the registration and meal times.
+- Travel is coordinated.
+- Promotion is still something we can do!
+
+## High-level end-of-grant timeline and goals
+
+- Finishing test 2 write up
+- Iterating on the recommendations document
+- What can we upstream and where? We spent some time discussing the [notebook style guide](https://github.com/spacetelescope/style-guides/blob/master/guides/jupyter-notebooks.md) as a long term place for some recommendations.


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR

-  Adds the March 2023 notes as a markdown file

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. 🌻 
