### PR TITLE
Create April 2023 meeting notes

### DIFF
--- a/notes/2023-04-25.md
+++ b/notes/2023-04-25.md
@@ -1,0 +1,36 @@
+# Astronomy Notebooks For All - April 25, 2023 notes
+
+## Updates
+
+### Jenn Update
+
+- Videos from event being edited to be sent to attendees
+- Open to event write ups, but has no current plans of what or where
+- Jenn will be preparing poster and talk for JupyterCon
+- Test 2 write up and 3 round of tests (after JupyterCon)
+- Admin stuff 
+
+### Isabela Update
+
+- Test 2 write up work.
+- To do a rough outline for test 3. Has not started yet.
+
+### Tony Update
+
+- Has questions he needs answered!
+    - What is the proper representation of cells? How do we represent cells in container. Five options. List. Feed. Three different kinds of tables (table, treegrid, grid).Once we know this we know aria roles we need specified and other tags.
+    - We have to figure out what the correct positioning of the cell form is. When you navigate stuff there are different orders of things. Execution number. Input and output positioning.
+- Working on getting these representations available for testing. We can meet and talk this out.
+- Minor website styling changes upcoming
+
+### Patrick Update
+
+- Will look into DOI acquisition.
+- Presented at ArXiv event. They have had accessibility efforts recently, - HTML, PDF, LaTeX conversations.
+
+## Post-event work
+
+- What resources do we want to put in our repo?
+- What writing are we interested in doing?
+- What resources go elsewhere?
+- Tony’s writing prompts (HackMD)


### PR DESCRIPTION
We agreed to keep our meeting notes public throughout the process. This PR

-  Adds the April 2023 notes as a markdown file

Please let me know if you have any questions! Feel free to suggest fixes to any errors you find. 🌻 
