### PR TITLE
the cell is landmark for a form

### DIFF
--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -15,6 +15,7 @@ import json
 import builtins
 import bs4
 import pygments
+from traitlets import Unicode
 import nbconvert_html5
 import pydantic
 import nbformat.v4
@@ -289,7 +290,7 @@ class FormExporter(HTMLExporter):
         pass
     A/B testing with out requiring `nbconvert` or notebook knowleldge."""
 
-    template_file = "semantic-forms/table.html.j2"
+    template_file = Unicode("semantic-forms/table.html.j2").tag(config=True)
     exclude_anchor_links = True
 
     def __init__(self, *args, **kwargs):

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -307,6 +307,7 @@ class FormExporter(HTMLExporter):
         import html
         self.environment.globals.update(json=json, markdown=markdown)
         self.environment.filters.update(escape_html=html.escape)
+        self.environment.globals.update(formatter=pygments.formatters)
 
 
     def from_notebook_node(self, nb, resources=None, **kw):

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -1,12 +1,6 @@
 {%- extends 'display_priority.j2' -%}
 {% from 'celltags.j2' import celltags %}
 
-{% block output %}
-<output form="{{ID}}" for="{{ID}}-source" role="document" class="output_area">
-{{ super() }}
-</output>
-{% endblock output %}
-
 {% block execute_result -%}
 {%- set extra_class="output_execute_result" -%}
 {% block data_priority scoped %}
@@ -178,3 +172,57 @@ var element = $('#{{ div_id }}');
 {%- endif %}
 {{ super() }}
 {%- endblock footer-%}
+
+
+
+{% macro cell_form(cell, nb) %}
+{% set count = nb["cells"].index(cell) +1%}
+{% set ID = "/cells/" + str(cell.id or count) %}
+<form id="{{ID}}" aria-label="Cell Source {{count}}">
+    {{cell_type_cell(cell)}}
+    <label>
+        <textarea name="source" id="{{ID}}/source" readonly>{{cell.source}}</textarea>
+    </label>
+</form>
+{{cell_toolbar(cell, ID)}}
+<output class="render" for="{{ID}}/source" form={{ID}} aria-hidden="{% if cell.cell_type == "markdown" %}false{% else %}true{% endif %}">
+    {% if cell.cell_type=="markdown" %}{{markdown(cell.source) | strip_files_prefix}}{% endif %}
+    {% if cell.cell_type=="code" %}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% endif %}
+</output>
+<output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/outputs">{{cell.execution_count or ""}}</output>
+<output form={{ID}} for="{{ID}}/source" name=outputs role=log>{{outputs_cell(cell, ID)}}</output>
+{% endmacro%}
+
+{% macro cell_type_cell(cell) %}
+{% set cell_type = cell.cell_type %}
+<label class="cell_type">
+    <select name="cell_type" disabled>
+        <option {% if cell_type=="code" %}selected{% endif %} value="code">code</option>
+        <option {% if cell_type=="markdown" %}selected{% endif %} value="markdown">markdown</option>
+        <option {% if cell_type=="raw" %}selected{% endif %} value="raw">raw</option>
+        <option {% if cell_type=="unknown" %}selected{% endif %} value="unknown">unknown</option>
+    </select>
+</label>
+{% endmacro %}
+
+{% macro outputs_cell(cell, ID) %}
+{% for i, output in enumerate(cell.outputs) %}
+{% block output scoped %}{% block output_prompt %}{% endblock %}{{super()}}{% endblock %}
+{% endfor %}
+{% endmacro %}
+
+
+{% macro cell_toolbar(cell, ID) %}
+<menu class="cell toolbar" hidden>
+    <input class="run" type="submit" form="{{ID}}" for="{{ID}}-source" value="run" title="run the cell"
+        tabindex="0">
+    <button onclick="document.querySelector('#{{ID}}-metadata').showModal()" title="show metadata">🛈</button>
+</menu>
+{% endmacro %}
+
+{% macro hide(x) %}{% if not x %}hidden{% endif %}{% endmacro %}
+
+
+{% macro highlight(body, type) %}
+{{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
+{% endmacro %}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -175,54 +175,54 @@ var element = $('#{{ div_id }}');
 
 
 
-{% macro cell_form(cell, nb) %}
-{% set count = nb["cells"].index(cell) +1%}
-{% set ID = "/cells/" + str(cell.id or count) %}
-<form id="{{ID}}" aria-label="Cell Source {{count}}">
-    {{cell_type_cell(cell)}}
-    <label>
-        <textarea name="source" id="{{ID}}/source" readonly>{{cell.source}}</textarea>
+    {% macro cell_form(cell, nb) %}
+    {% set count = nb["cells"].index(cell) +1%}
+    {% set ID = "/cells/" + str(cell.id or count) %}
+    <form id="{{ID}}" aria-label="Cell Source {{count}}">
+        {{cell_type_cell(cell)}}
+        <label>
+            <textarea name="source" id="{{ID}}/source" readonly>{{cell.source}}</textarea>
+        </label>
+    </form>
+    {{cell_toolbar(cell, ID)}}
+    <output class="render" for="{{ID}}/source" form={{ID}} aria-hidden="{% if cell.cell_type == "markdown" %}false{% else %}true{% endif %}">
+        {% if cell.cell_type=="markdown" %}{{markdown(cell.source) | strip_files_prefix}}{% endif %}
+        {% if cell.cell_type=="code" %}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% endif %}
+    </output>
+    <output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/outputs">{{cell.execution_count or ""}}</output>
+    <output form={{ID}} for="{{ID}}/source" name=outputs role=log>{{outputs_cell(cell, ID)}}</output>
+    {% endmacro%}
+
+    {% macro cell_type_cell(cell) %}
+    {% set cell_type = cell.cell_type %}
+    <label class="cell_type">
+        <select name="cell_type" disabled>
+            <option {% if cell_type=="code" %}selected{% endif %} value="code">code</option>
+            <option {% if cell_type=="markdown" %}selected{% endif %} value="markdown">markdown</option>
+            <option {% if cell_type=="raw" %}selected{% endif %} value="raw">raw</option>
+            <option {% if cell_type=="unknown" %}selected{% endif %} value="unknown">unknown</option>
+        </select>
     </label>
-</form>
-{{cell_toolbar(cell, ID)}}
-<output class="render" for="{{ID}}/source" form={{ID}} aria-hidden="{% if cell.cell_type == "markdown" %}false{% else %}true{% endif %}">
-    {% if cell.cell_type=="markdown" %}{{markdown(cell.source) | strip_files_prefix}}{% endif %}
-    {% if cell.cell_type=="code" %}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% endif %}
-</output>
-<output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/outputs">{{cell.execution_count or ""}}</output>
-<output form={{ID}} for="{{ID}}/source" name=outputs role=log>{{outputs_cell(cell, ID)}}</output>
-{% endmacro%}
+    {% endmacro %}
 
-{% macro cell_type_cell(cell) %}
-{% set cell_type = cell.cell_type %}
-<label class="cell_type">
-    <select name="cell_type" disabled>
-        <option {% if cell_type=="code" %}selected{% endif %} value="code">code</option>
-        <option {% if cell_type=="markdown" %}selected{% endif %} value="markdown">markdown</option>
-        <option {% if cell_type=="raw" %}selected{% endif %} value="raw">raw</option>
-        <option {% if cell_type=="unknown" %}selected{% endif %} value="unknown">unknown</option>
-    </select>
-</label>
-{% endmacro %}
-
-{% macro outputs_cell(cell, ID) %}
-{% for i, output in enumerate(cell.outputs) %}
-{% block output scoped %}{% block output_prompt %}{% endblock %}{{super()}}{% endblock %}
-{% endfor %}
-{% endmacro %}
+    {% macro outputs_cell(cell, ID) %}
+    {% for i, output in enumerate(cell.outputs) %}
+    {% block output scoped %}{% block output_prompt %}{% endblock %}{{super()}}{% endblock %}
+    {% endfor %}
+    {% endmacro %}
 
 
-{% macro cell_toolbar(cell, ID) %}
-<menu class="cell toolbar" hidden>
-    <input class="run" type="submit" form="{{ID}}" for="{{ID}}-source" value="run" title="run the cell"
-        tabindex="0">
-    <button onclick="document.querySelector('#{{ID}}-metadata').showModal()" title="show metadata">🛈</button>
-</menu>
-{% endmacro %}
+    {% macro cell_toolbar(cell, ID) %}
+    <menu class="cell toolbar" hidden>
+        <input class="run" type="submit" form="{{ID}}" for="{{ID}}-source" value="run" title="run the cell"
+            tabindex="0">
+        <button onclick="document.querySelector('#{{ID}}-metadata').showModal()" title="show metadata">🛈</button>
+    </menu>
+    {% endmacro %}
 
-{% macro hide(x) %}{% if not x %}hidden{% endif %}{% endmacro %}
+    {% macro hide(x) %}{% if not x %}hidden{% endif %}{% endmacro %}
 
 
-{% macro highlight(body, type) %}
-{{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
-{% endmacro %}
+    {% macro highlight(body, type) %}
+    {{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
+    {% endmacro %}

--- a/nbconvert_html5/templates/semantic-forms/cell.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/cell.html.j2
@@ -95,8 +95,7 @@ of the execution count label on different elements with different roles.
 
 {%- macro cell_display_priority(cell, ID) -%}
 {%- for i, output in enumerate(cell.outputs) -%}
-{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock
-    -%}{{super()}}</output>{%- endblock -%}
+{%- block output scoped -%}{%- block output_prompt -%}{%- endblock-%}{{super()}}{%- endblock -%}
 {%- endfor -%}
 {%- endmacro -%}
 

--- a/nbconvert_html5/templates/semantic-forms/cell.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/cell.html.j2
@@ -37,9 +37,9 @@
 {%- macro cell_execution_count(cell, nb, body) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% if cell.cell_type == "code" %}
-<output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count" title="Execution count">Out: {{cell.execution_count or ""}}</output>
+<label for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count">Out: {{cell.execution_count or ""}}</label>
 {% else %}
-<output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count" title="Execution count">Cell {{count}}</output>
+<label for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count">Cell {{count}}</label>
 {% endif %}
 {%- endmacro -%}
 

--- a/nbconvert_html5/templates/semantic-forms/cell.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/cell.html.j2
@@ -1,0 +1,68 @@
+{%- extends 'semantic-forms/index.html.j2' -%}
+
+{%- macro cell_textarea(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<textarea name="source" id="{{ID}}/source" readonly aria-label="{{cell.cell_type}} source">{{cell.source}}</textarea>
+{%- endmacro -%}
+
+
+{%- macro cell_forms(cell, nb, body) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<form id="{{ID}}" name="{{ID}}" method="POST">
+{{body}}
+</form>
+{%- endmacro -%}
+
+{%- macro cell_submit(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<button form="{{ID}}" type="submit" disabled>Run</button>
+{%- endmacro -%}
+
+{%- macro cell_toolbars(cell, nb, body) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<ul role="toolbar" aria-labelledby="{{ID}}/execution_count">{%- for part in body -%}<li>{{part}}</li>{%- endfor -%}</ul>
+{%- endmacro -%}
+
+{%- macro cell_type(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{%- set cell_type = cell.cell_type -%}
+<select name="cell_type" aria-label="Cell Type" form="{{ID}}" disabled>
+    <option {% if cell_type=="code" %}selected{% endif %} value="code">code</option>
+    <option {% if cell_type=="markdown" %}selected{% endif %} value="markdown">markdown</option>
+    <option {% if cell_type=="raw" %}selected{% endif %} value="raw">raw</option>
+    <option {% if cell_type=="unknown" %}selected{% endif %} value="unknown">unknown</option>
+</select>
+{%- endmacro -%}
+
+{%- macro cell_execution_count(cell, nb, body) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{% if cell.cell_type == "code" %}
+<output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count" title="Execution count">Out: {{cell.execution_count or ""}}</output>
+{% else %}
+<output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count" title="Execution count">Cell {{count}}</output>
+{% endif %}
+{%- endmacro -%}
+
+{%- macro cell_outputs(cell, nb, parts) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<fieldset name="outputs" id="{{ID}}/outputs">{{cell_display_priority(cell, ID)}}</fieldset>
+{%- endmacro -%}
+
+{%- macro cell_render(cell, nb, parts) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{% set CODE = cell.cell_type=="code" %}
+<output class="render" for="{{ID}}/source" form={{ID}} aria-labelledby="{{ID}}/execution_count">
+{%- if CODE -%}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% else %}{{markdown(cell.source) | strip_files_prefix}}{%- endif -%}
+</output>
+{%- endmacro -%}
+
+{%- macro cell_display_priority(cell, ID) -%}
+{%- for i, output in enumerate(cell.outputs) -%}
+{%- block output scoped -%}<output name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" for="{{ID}}/source" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock -%}{{super()}}</output>{%- endblock -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+
+{%- macro highlight(body, type) -%}
+{{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
+{%- endmacro -%}

--- a/nbconvert_html5/templates/semantic-forms/cell.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/cell.html.j2
@@ -78,7 +78,7 @@ of the execution count label on different elements with different roles.
 
 {%- macro cell_outputs(cell, nb, parts) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<fieldset name="outputs" id="{{ID}}/outputs" {%- if not cell.outputs %}hidden{% endif %}>
+<fieldset name="outputs" id="{{ID}}/outputs" role="presentation" {%- if not cell.outputs %}hidden{% endif %}>
     <legend>{{ cell_execution_count_out(cell, nb) }}</legend>
     {{cell_display_priority(cell, ID)}}
 </fieldset>

--- a/nbconvert_html5/templates/semantic-forms/cell.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/cell.html.j2
@@ -1,26 +1,33 @@
 {%- extends 'semantic-forms/index.html.j2' -%}
 
-{# cell is a tough analogy, it is an ambiguous signifier dependent on context. 
+{# cell is a tough analogy, it is an ambiguous signifier dependent on context.
 the analogy to a biologic cell asks "what is the nucleus?" or "what encodes the objective?".
 the source input feels like it is the irreducible element of our computational cells.
 lines of text evolve over time. like dna they replicate, mutate, evolve, and cooperate.
 
 allied alphabets dancing on carefully organized sand emitting waves of sound, light, and hope.
-the lines in the source, the nucleus, freeze a sliver of a movement in hypermedia. 
+the lines in the source, the nucleus, freeze a sliver of a movement in hypermedia.
 
 #}
 {%- macro cell_textarea(cell, nb) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<label for="{{ID}}/source"></label>{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
-<textarea name="source" id="{{ID}}/source" readonly>{{cell.source}}</textarea>
+<label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
+    <textarea name="source" id="{{ID}}/source" form="{{ID}}" readonly>{{cell.source}}</textarea>
+</label>
 {%- endmacro -%}
 
 
 {%- macro cell_forms(cell, nb, body) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<form id="{{ID}}" name="{{ID}}" method="POST">
-{{body}}
+<form id="{{ID}}" name="{{ID}}" method="POST" aria-labelledby="{{ID}}/execution_count">
+    {{body}}
 </form>
+{%- endmacro -%}
+
+
+{%- macro cell_form_element(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<form id="{{ID}}" name="{{ID}}" method="POST"></form>
 {%- endmacro -%}
 
 {%- macro cell_submit(cell, nb) -%}
@@ -45,12 +52,12 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
 </select>
 {%- endmacro -%}
 
-{# the execution count has been one of the most confusing aspects of this journey. 
-it's meaning wasn't revealed until the very end of this rigorous study. 
+{# the execution count has been one of the most confusing aspects of this journey.
+it's meaning wasn't revealed until the very end of this rigorous study.
 the result discovered labelable, interactive elements that describe the components of the cell.
 assistive technology requires labels for interactive objects and the semantic representation allows the re-use
 of the execution count label on different elements with different roles.
- #}
+#}
 {%- macro cell_execution_count_out(cell, nb, body) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% if cell.cell_type == "code" %}
@@ -81,13 +88,16 @@ of the execution count label on different elements with different roles.
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% set CODE = cell.cell_type=="code" %}
 <output role="presentation" class="render" for="{{ID}}/source" form={{ID}} aria-labelledby="{{ID}}/execution_count">
-{%- if CODE -%}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% else %}{{markdown(cell.source) | strip_files_prefix}}{%- endif -%}
+    {%- if CODE -%}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% else %}{{markdown(cell.source) |
+    strip_files_prefix}}{%- endif -%}
 </output>
 {%- endmacro -%}
 
 {%- macro cell_display_priority(cell, ID) -%}
 {%- for i, output in enumerate(cell.outputs) -%}
-{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" for="{{ID}}/source" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock -%}{{super()}}</output>{%- endblock -%}
+{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}"
+    for="{{ID}}/source" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock
+    -%}{{super()}}</output>{%- endblock -%}
 {%- endfor -%}
 {%- endmacro -%}
 

--- a/nbconvert_html5/templates/semantic-forms/cell.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/cell.html.j2
@@ -1,8 +1,18 @@
 {%- extends 'semantic-forms/index.html.j2' -%}
 
+{# cell is a tough analogy, it is an ambiguous signifier dependent on context. 
+the analogy to a biologic cell asks "what is the nucleus?" or "what encodes the objective?".
+the source input feels like it is the irreducible element of our computational cells.
+lines of text evolve over time. like dna they replicate, mutate, evolve, and cooperate.
+
+allied alphabets dancing on carefully organized sand emitting waves of sound, light, and hope.
+the lines in the source, the nucleus, freeze a sliver of a movement in hypermedia. 
+
+#}
 {%- macro cell_textarea(cell, nb) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<textarea name="source" id="{{ID}}/source" readonly aria-label="{{cell.cell_type}} source">{{cell.source}}</textarea>
+<label for="{{ID}}/source"></label>{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
+<textarea name="source" id="{{ID}}/source" readonly>{{cell.source}}</textarea>
 {%- endmacro -%}
 
 
@@ -15,7 +25,8 @@
 
 {%- macro cell_submit(cell, nb) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<button form="{{ID}}" type="submit" disabled>Run</button>
+{# https://www.w3.org/TR/WCAG20-TECHS/H32.html #}
+<button form="{{ID}}" type="submit" disabled aria-label="Run Cell"></button>
 {%- endmacro -%}
 
 {%- macro cell_toolbars(cell, nb, body) -%}
@@ -34,7 +45,13 @@
 </select>
 {%- endmacro -%}
 
-{%- macro cell_execution_count(cell, nb, body) -%}
+{# the execution count has been one of the most confusing aspects of this journey. 
+it's meaning wasn't revealed until the very end of this rigorous study. 
+the result discovered labelable, interactive elements that describe the components of the cell.
+assistive technology requires labels for interactive objects and the semantic representation allows the re-use
+of the execution count label on different elements with different roles.
+ #}
+{%- macro cell_execution_count_out(cell, nb, body) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% if cell.cell_type == "code" %}
 <label for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count">Out: {{cell.execution_count or ""}}</label>
@@ -43,22 +60,34 @@
 {% endif %}
 {%- endmacro -%}
 
+{%- macro cell_execution_count_in(cell, nb, body) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{% if cell.cell_type == "code" %}
+<label for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count">In: {{cell.execution_count or ""}}</label>
+{% else %}
+<label for="{{ID}}/source" name=execution_count id="{{ID}}/execution_count">Cell {{count}}</label>
+{% endif %}
+{%- endmacro -%}
+
 {%- macro cell_outputs(cell, nb, parts) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<fieldset name="outputs" id="{{ID}}/outputs">{{cell_display_priority(cell, ID)}}</fieldset>
+<fieldset name="outputs" id="{{ID}}/outputs" {%- if not cell.outputs %}hidden{% endif %}>
+    <legend>{{ cell_execution_count_out(cell, nb) }}</legend>
+    {{cell_display_priority(cell, ID)}}
+</fieldset>
 {%- endmacro -%}
 
 {%- macro cell_render(cell, nb, parts) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% set CODE = cell.cell_type=="code" %}
-<output class="render" for="{{ID}}/source" form={{ID}} aria-labelledby="{{ID}}/execution_count">
+<output role="presentation" class="render" for="{{ID}}/source" form={{ID}} aria-labelledby="{{ID}}/execution_count">
 {%- if CODE -%}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% else %}{{markdown(cell.source) | strip_files_prefix}}{%- endif -%}
 </output>
 {%- endmacro -%}
 
 {%- macro cell_display_priority(cell, ID) -%}
 {%- for i, output in enumerate(cell.outputs) -%}
-{%- block output scoped -%}<output name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" for="{{ID}}/source" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock -%}{{super()}}</output>{%- endblock -%}
+{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" for="{{ID}}/source" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock -%}{{super()}}</output>{%- endblock -%}
 {%- endfor -%}
 {%- endmacro -%}
 

--- a/nbconvert_html5/templates/semantic-forms/cell.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/cell.html.j2
@@ -87,7 +87,7 @@ of the execution count label on different elements with different roles.
 {%- macro cell_render(cell, nb, parts) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% set CODE = cell.cell_type=="code" %}
-<output role="presentation" class="render" for="{{ID}}/source" form={{ID}} aria-labelledby="{{ID}}/execution_count">
+<output role="presentation" class="render" form={{ID}} aria-labelledby="{{ID}}/execution_count">
     {%- if CODE -%}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% else %}{{markdown(cell.source) |
     strip_files_prefix}}{%- endif -%}
 </output>
@@ -95,8 +95,7 @@ of the execution count label on different elements with different roles.
 
 {%- macro cell_display_priority(cell, ID) -%}
 {%- for i, output in enumerate(cell.outputs) -%}
-{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}"
-    for="{{ID}}/source" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock
+{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock
     -%}{{super()}}</output>{%- endblock -%}
 {%- endfor -%}
 {%- endmacro -%}

--- a/nbconvert_html5/templates/semantic-forms/feed.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/feed.html.j2
@@ -1,0 +1,13 @@
+{%- extends 'semantic-forms/index.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+{% block body_loop %}
+<section role="feed">{{super()}}</section>
+{% endblock body_loop %}
+
+{% block any_cell %}
+<article class="cell {{cell.cell_type}} {{celltags(cell)}}">
+{{cell_form(cell, nb)}}
+</article>
+{% endblock any_cell %}

--- a/nbconvert_html5/templates/semantic-forms/forms.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/forms.html.j2
@@ -1,0 +1,61 @@
+{%- extends 'semantic-forms/index.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+
+{% block any_cell %}
+{{cell_section(cell, nb, resources)}}
+{% endblock any_cell %}
+
+{% macro highlight(body, type) %}
+{{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
+{% endmacro %}
+
+
+{% macro cell_section(cell, nb, resources={}) %}
+{% set count = nb.cells.index(cell) %}
+{% set ID = "/cells/" + str(cell.id or count) %}
+<form id="{{ID}}">
+    {{cell_type_cell(cell)}}
+    <label>
+        <textarea name="source" id="{{ID}}/source">{{cell.source}}</textarea>
+    </label>
+</form>
+{{cell_toolbar(cell, ID)}}
+<output class="render" for="{{ID}}/source" form={{ID}} aria-hidden="{% if cell.cell_type == "markdown" %}false{% else %}true{% endif %}">
+    {% if cell.cell_type=="markdown" %}{{markdown(cell.source) | strip_files_prefix}}{% endif %}
+    {% if cell.cell_type=="code" %}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% endif %}
+</output>
+<output form={{ID}} for="{{ID}}/source" name=execution_count id="{{ID}}/outputs">{{cell.execution_count or ""}}</output>
+<output form={{ID}} for="{{ID}}/source" name=outputs role=log>{{outputs_cell(cell, ID)}}</output>
+{% endmacro %}
+
+
+{% macro cell_type_cell(cell) %}
+{% set cell_type = cell.cell_type %}
+<label class="cell_type">
+    <select name="cell_type" disabled>
+        <option {% if cell_type=="code" %}selected{% endif %} value="code">code</option>
+        <option {% if cell_type=="markdown" %}selected{% endif %} value="markdown">markdown</option>
+        <option {% if cell_type=="raw" %}selected{% endif %} value="raw">raw</option>
+        <option {% if cell_type=="unknown" %}selected{% endif %} value="unknown">unknown</option>
+    </select>
+</label>
+{% endmacro %}
+
+{% macro outputs_cell(cell, ID) %}
+{% for i, output in enumerate(cell.outputs) %}
+{% block output scoped %}{% block output_prompt %}{% endblock %}{{super()}}{% endblock %}
+{% endfor %}
+{% endmacro %}
+
+
+{% macro cell_toolbar(cell, ID) %}
+<menu class="cell toolbar">
+    <input class="run" type="submit" form="{{ID}}" for="{{ID}}-source" value="run" title="run the cell"
+        tabindex="0">
+    <button onclick="document.querySelector('#{{ID}}-metadata').showModal()" title="show metadata">🛈</button>
+</menu>
+{% endmacro %}
+
+{% macro hide(x) %}{% if not x %}hidden{% endif %}{% endmacro %}

--- a/nbconvert_html5/templates/semantic-forms/index.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/index.html.j2
@@ -2,22 +2,33 @@
 {% from 'mathjax.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
+{%- block header -%}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{%- block html_head -%}
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
+<title>{{nb_title}}</title>
+{% block css %}{% endblock css %}
+{%- endblock html_head -%}
+</head>
+{%- endblock  -%}
+
+
 {% block body_header %}
 <body>
     <header class="site">
-        {% block skip_links %}<a class="visually-hidden" tabindex="0" href="#/cells">Skip to Main Content</a>{% endblock skip_links %}
-        {% block site_header %}<nav id="toc"></nav>{% endblock site_header %}
-        <!-- search and site navigation would go here -->
-        <!-- links go to the original content -->
+        {% block skip_links %}<a class="visually-hidden" tabindex="0" href="#/cells">Skip to content</a>{% endblock skip_links %}
     </header>
-    <main>
-        <header>{% block nb_header %}<nav id="toc"></nav>{% endblock nb_header %}</header>
+    <main id="/">
 {% endblock body_header %}
 
 
 {% block body_footer %}
-        <footer>{% block site_footer %}<!-- site license -->{% endblock site_footer %}</footer>
     </main>
+    <footer><a class="scroll-top" href="#/">Scroll to top.</a></footer>
 </body>
 {% endblock body_footer %}
 

--- a/nbconvert_html5/templates/semantic-forms/index.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/index.html.j2
@@ -20,7 +20,7 @@
 {% block body_header %}
 <body>
     <header class="site">
-        {% block skip_links %}<a class="visually-hidden" tabindex="0" href="#/cells">Skip to content</a>{% endblock skip_links %}
+        {% block skip_links %}<a class="visually-hidden" tabindex="0" href="#/">Skip to content</a>{% endblock skip_links %}
     </header>
     <main id="/">
 {% endblock body_header %}

--- a/nbconvert_html5/templates/semantic-forms/index.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/index.html.j2
@@ -1,0 +1,30 @@
+{%- extends 'semantic-forms/base.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+{% block body_header %}
+<body>
+    <header class="site">
+        {% block skip_links %}<a class="visually-hidden" tabindex="0" href="#/cells">Skip to Main Content</a>{% endblock skip_links %}
+        {% block site_header %}<nav id="toc"></nav>{% endblock site_header %}
+        <!-- search and site navigation would go here -->
+        <!-- links go to the original content -->
+    </header>
+    <main>
+        <header>{% block nb_header %}<nav id="toc"></nav>{% endblock nb_header %}</header>
+{% endblock body_header %}
+
+
+{% block body_footer %}
+        <footer>{% block site_footer %}<!-- site license -->{% endblock site_footer %}</footer>
+    </main>
+</body>
+{% endblock body_footer %}
+
+{% block footer %}
+{% block footer_js %}
+{% endblock footer_js %}
+{{ super() }}
+</html>
+{% endblock footer %}
+

--- a/nbconvert_html5/templates/semantic-forms/ol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/ol.html.j2
@@ -1,0 +1,13 @@
+{%- extends 'semantic-forms/index.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+{% block body_loop %}
+<ol>{{super()}}</ol>
+{% endblock body_loop %}
+
+{% block any_cell %}
+<li class="cell {{cell.cell_type}} {{celltags(cell)}}">
+{{cell_form(cell, nb)}}
+</li>
+{% endblock any_cell %}

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -1,10 +1,32 @@
-{%- extends 'semantic-forms/index.html.j2' -%}
+{%- extends 'semantic-forms/cell.html.j2' -%}
 {% from 'mathjax.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
 
+{% block css %}
+<style>
+section.cell [role=toolbar]:has(button[type="submit"]:disabled),
+section.cell :is(fieldset:empty, textarea:read-only),
+section.markdown [name="execution_count"] {
+    display: none;
+}
+[name=execution_count] {
+    font-family: monospace;
+}
+section.cell > fieldset {
+   border: none;
+}
+</style>{% endblock css %}
+
 {% block any_cell %}
-<section aria-label="Cell {{count}}" class="cell {{cell.cell_type}} {{celltags(cell)}}" id="/cells/{{count}}">
-{{cell_form(cell, nb)}}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{%- set CODE = cell.cell_type == "code" -%}
+
+<section {% if CODE %}aria-labelledby="{{ID}}/execution_count"{% endif %} class="cell {{cell.cell_type}} {{celltags(cell)}}" id="{{count}}">
+{{ cell_execution_count(cell, nb) }}
+{{ cell_forms(cell, nb, cell_textarea(cell, nb))}}
+{{ cell_render(cell, nb) }}
+{{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
+{{ cell_outputs(cell, nb) }}
 </section>
 {% endblock any_cell %}

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -24,6 +24,10 @@
         display: none;
     }
 
+    fieldset[name$=put] > output {
+        width: 100%
+    }
+
     [name=execution_count] {
         font-family: monospace;
     }
@@ -31,6 +35,7 @@
     main>section {
         display: flex;
         flex-direction: column;
+        align-items: stretch;
     }
 
     main>section>fieldset[name=input] {
@@ -73,9 +78,7 @@
 {% block any_cell scoped %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {%- set CODE = cell.cell_type == "code" -%}
-
-<section {% if CODE %}aria-labelledby="{{ID}}/execution_count" {% endif %}
-    class="cell {{cell.cell_type}} {{celltags(cell)}}" id="{{count}}">
+<section {% if CODE %}aria-labelledby="{{ID}}/execution_count" {% endif %} class="cell {{cell.cell_type}} {{celltags(cell)}}" id="{{count}}">
     {{ input_group(cell, nb) }}
     {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     {{ cell_outputs(cell, nb) }}

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -58,7 +58,7 @@
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {{ cell_form_element(cell, nb)}}
 <fieldset for="{{ID}}" name="input" disabled>
-    <legend aria-hidden="true">{{ cell_execution_count_in(cell, nb) }}</legend>
+    <legend>{{ cell_execution_count_in(cell, nb) }}</legend>
     {{ cell_textarea(cell, nb) }}
     {{ cell_render(cell, nb) }}
 </fieldset>

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -2,8 +2,8 @@
 {% from 'mathjax.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
-
 {% block css %}
+<meta name="color-scheme" content="dark light">
 <style>
     body {
         font-size: larger;
@@ -52,6 +52,12 @@
         white-space: nowrap;
         width: 1px;
     }
+
+{{formatter.get_formatter_by_name("html", style="github-light").get_style_defs(".highlight")}}
+@media (prefers-color-scheme: dark) { 
+    {{formatter.get_formatter_by_name("html", style="github-dark").get_style_defs(".highlight")}}
+ }
+
 </style>{% endblock css %}
 
 {% macro input_group(cell, nb) %}

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -5,25 +5,59 @@
 
 {% block css %}
 <style>
-section.cell [role=toolbar]:has(button[type="submit"]:disabled),
-section.cell fieldset:empty, 
-section.cell textarea:read-only,
-section.markdown [name="execution_count"] {
+main {
+    display: flex;
+    overflow-x: hidden;
+    flex-direction: column;
+    flex-wrap: nowrap;
+}
+section.cell [role=toolbar],
+section.cell textarea[name=source]:read-only,
+section.markdown > fieldset[name=outputs],
+section.markdown > fieldset[name=input] > legend {
     display: none;
 }
 [name=execution_count] {
     font-family: monospace;
 }
+main > section {
+    display: flex;
+    flex-direction: column;
+    align-content: stretch;
+}
+
+main > section > fieldset[name=input] {
+    border: none;
+    display: flex;
+    flex-direction: row;
+
+}
+
+main > section > fieldset[name=input] legend {
+    display: inherit;
+
+}
+
+main > section {
+    overflow-x: auto;
+}
 </style>{% endblock css %}
+
+{% macro input_group(cell, nb) %}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<fieldset for="{{ID}}" name="input">
+    <legend {% if cell.cell_type!="code" %}aria-hidden="true"{% endif %}>{{ cell_execution_count_in(cell, nb) }}</legend>
+    {{ cell_forms(cell, nb, cell_textarea(cell, nb))}}
+    {{ cell_render(cell, nb) }}
+</fieldset>
+{% endmacro %}
 
 {% block any_cell %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {%- set CODE = cell.cell_type == "code" -%}
 
 <section {% if CODE %}aria-labelledby="{{ID}}/execution_count"{% endif %} class="cell {{cell.cell_type}} {{celltags(cell)}}" id="{{count}}">
-{{ cell_execution_count(cell, nb) }}
-{{ cell_forms(cell, nb, cell_textarea(cell, nb))}}
-{{ cell_render(cell, nb) }}
+{{ input_group(cell, nb) }}
 {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
 {{ cell_outputs(cell, nb) }}
 </section>

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -6,15 +6,13 @@
 {% block css %}
 <style>
 section.cell [role=toolbar]:has(button[type="submit"]:disabled),
-section.cell :is(fieldset:empty, textarea:read-only),
+section.cell fieldset:empty, 
+section.cell textarea:read-only,
 section.markdown [name="execution_count"] {
     display: none;
 }
 [name=execution_count] {
     font-family: monospace;
-}
-section.cell > fieldset {
-   border: none;
 }
 </style>{% endblock css %}
 

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -5,60 +5,73 @@
 
 {% block css %}
 <style>
-main {
-    display: flex;
-    overflow-x: hidden;
-    flex-direction: column;
-    flex-wrap: nowrap;
-}
-section.cell [role=toolbar],
-section.cell textarea[name=source]:read-only,
-section.markdown > fieldset[name=outputs],
-section.markdown > fieldset[name=input] > legend {
-    display: none;
-}
-[name=execution_count] {
-    font-family: monospace;
-}
-main > section {
-    display: flex;
-    flex-direction: column;
-    align-content: stretch;
-}
+    body {
+        font-size: larger;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    }
 
-main > section > fieldset[name=input] {
-    border: none;
-    display: flex;
-    flex-direction: row;
+    main {
+        display: flex;
+        overflow-x: hidden;
+        flex-direction: column;
+    }
 
-}
+    fieldset[name=input]:disabled~form,
+    fieldset[name=input]:disabled~ul[role=toolbar],
+    fieldset[name=input]:disabled>label[for$="\/source"],
+    section.markdown>fieldset[name=input]>legend,
+    section.markdown>fieldset[name=outputs] {
+        display: none;
+    }
 
-main > section > fieldset[name=input] legend {
-    display: inherit;
+    [name=execution_count] {
+        font-family: monospace;
+    }
 
-}
+    main>section {
+        display: flex;
+        flex-direction: column;
+    }
 
-main > section {
-    overflow-x: auto;
-}
+    main>section>fieldset[name=input] {
+        border: none;
+        display: flex;
+        flex-direction: row;
+    }
+
+    main>section {
+        overflow-x: auto;
+    }
+
+    .visually-hidden:not(:focus):not(:active) {
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+    }
 </style>{% endblock css %}
 
 {% macro input_group(cell, nb) %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<fieldset for="{{ID}}" name="input">
-    <legend {% if cell.cell_type!="code" %}aria-hidden="true"{% endif %}>{{ cell_execution_count_in(cell, nb) }}</legend>
-    {{ cell_forms(cell, nb, cell_textarea(cell, nb))}}
+{{ cell_form_element(cell, nb)}}
+<fieldset for="{{ID}}" name="input" disabled>
+    <legend aria-hidden="true">{{ cell_execution_count_in(cell, nb) }}</legend>
+    {{ cell_textarea(cell, nb) }}
     {{ cell_render(cell, nb) }}
 </fieldset>
 {% endmacro %}
 
-{% block any_cell %}
+{% block any_cell scoped %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {%- set CODE = cell.cell_type == "code" -%}
 
-<section {% if CODE %}aria-labelledby="{{ID}}/execution_count"{% endif %} class="cell {{cell.cell_type}} {{celltags(cell)}}" id="{{count}}">
-{{ input_group(cell, nb) }}
-{{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
-{{ cell_outputs(cell, nb) }}
+<section {% if CODE %}aria-labelledby="{{ID}}/execution_count" {% endif %}
+    class="cell {{cell.cell_type}} {{celltags(cell)}}" id="{{count}}">
+    {{ input_group(cell, nb) }}
+    {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
+    {{ cell_outputs(cell, nb) }}
 </section>
 {% endblock any_cell %}

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -1,0 +1,10 @@
+{%- extends 'semantic-forms/index.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+
+{% block any_cell %}
+<section aria-label="Cell {{count}}" class="cell {{cell.cell_type}} {{celltags(cell)}}" id="/cells/{{count}}">
+{{cell_form(cell, nb)}}
+</section>
+{% endblock any_cell %}

--- a/nbconvert_html5/templates/semantic-forms/sections.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/sections.html.j2
@@ -68,7 +68,7 @@
 {% macro input_group(cell, nb) %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {{ cell_form_element(cell, nb)}}
-<fieldset for="{{ID}}" name="input" disabled>
+<fieldset for="{{ID}}" name="input" disabled {% if cell.cell_type == "markdown" %}role="presentation"{% endif %}>
     <legend>{{ cell_execution_count_in(cell, nb) }}</legend>
     {{ cell_textarea(cell, nb) }}
     {{ cell_render(cell, nb) }}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -140,3 +140,14 @@
 {%- endfor -%}
 {%- endmacro -%}
 
+
+
+{% block body_header %}
+<body>
+    {% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
+    <header class="site">
+        <label id="title" aria-hidden="true">{{title}}</label>
+        {% block skip_links %}<a class="visually-hidden" tabindex="0" href="#/">Skip to content</a>{% endblock skip_links %}
+    </header>
+    <main id="/" aria-label="{{title}}">
+{% endblock body_header %}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -27,8 +27,7 @@
 
     /** layout **/
     fieldset[name=input]:disabled~ul[role=toolbar],
-    form[action=markdown]+section>fieldset[name=input]:disabled,
-    form[action=markdown]+section>fieldset[name=input]:disabled~fieldset[name=outputs] legend {
+    form[action=markdown]+section>fieldset[name=input]:disabled {
         display: none;
     }
 
@@ -124,7 +123,7 @@
 {% set CODE = cell.cell_type == "code" %}
 
 <fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}hidden{% endif %} {% if not CODE %}role="presentation"{% endif %}>
-    <legend id={{ID}}/execution_count>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
+    <legend id={{ID}}/execution_count {% if not CODE %}hidden{% endif %}>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}
     <output role="presentation" class="render">{{markdown(cell.source) | strip_files_prefix}}</output>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -79,7 +79,7 @@
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {%- set CODE = cell.cell_type == "code" -%}
 {%- set tags = celltags(cell) -%}
-<form hidden id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}">
+<form hidden id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
     <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
 </form>
 <section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -67,6 +67,7 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
     textarea[name=source]:disabled {
         color: inherit;
     }
+
     textarea[name=source], fieldset[name$=put]>output {
         width: 100%;
     }
@@ -115,9 +116,8 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
         <legend>
             <output name="input_count" role="presentation">{{cell.execution_count or ""}}</output>
         </legend>
-        <label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
-        </label>
-        <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" readonly>{{cell.source}}</textarea>
+        <label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}Source</label>
+        <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}">{{cell.source}}</textarea>
     </fieldset>
     {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     {{ cell_output(cell, nb) }}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -37,6 +37,7 @@
         display: flex;
         overflow-x: hidden;
         flex-direction: column;
+        margin: 1rem;
     }
 
     main>section {
@@ -46,19 +47,24 @@
         gap: 1rem 1rem;
     }
 
-    main>section>fieldset[name=input],
-    main>section.markdown>fieldset[name=outputs] {
+    main>section>fieldset[name=input] {
         border: none;
-        display: flex;
-        flex-direction: row;
+    }
+   
+    fieldset[name=outputs] {
+        overflow: auto;
+        border: 0;
+        padding: 0.01em 0 0 0;
+        margin: 0;
+        min-width: 0;
+    }
+
+    body:not(:-moz-handler-blocked) fieldset[name=outputs] {
+        display: table-cell;
     }
 
     textarea[name=source], fieldset[name$=put]>output {
         width: 100%;
-    }
-
-    main>section {
-        overflow-x: auto;
     }
 
     /** fix the color constrast on disabled textareas **/

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -87,6 +87,7 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
         white-space: nowrap;
         width: 1px;
     }
+
 </style>{% endblock css %}
 {% block any_cell scoped %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
@@ -97,7 +98,16 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
         <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
     </form>
     <fieldset name=input role=presentation disabled>
-        <label id="{{ID}}/input_count">In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
+        {# its recommended to use a legend, but we want the legend to name the textarea. it makes semantic sense to use a fieldset for the input
+        
+        the visual label doubles the content of the legend, but this is similar to a recommended  pattern from https://adrianroselli.com/2022/07/use-legend-and-fieldset.html 
+        
+        with fieldset[role=presentation] and legend[hidden] the In group not announced entering the group. 
+        instead the "In" is only announced in the textarea and the visual `label` is hidden from assistive tech.
+        #}
+        <legend hidden id="{{ID}}/input_count">In&nbsp;<output name="input_count" role="presentation">{{cell.execution_count or ""}}</output></legend>
+        {# semantically a label with the same contents as the legend above. it only exists for visual purposes. #}
+        <label aria-hidden=true>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
         <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" aria-labelledby="{{ID}}/input_count">{{cell.source}}</textarea>
     </fieldset>
     {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
@@ -128,26 +138,6 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
 </select>
 {%- endmacro -%}
 
-{# the execution count has been one of the most confusing aspects of this journey.
-it's meaning wasn't revealed until the very end of this rigorous study.
-the result discovered labelable, interactive elements that describe the components of the cell.
-assistive technology requires labels for interactive objects and the semantic representation allows the re-use
-of the execution count label on different elements with different roles.
-#}
-{%- macro cell_out(cell, nb, body) -%}
-{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-{% if cell.cell_type == "code" %}
-<output name="execution_count" id={{ID}}/execution_count role="presentation">{{cell.execution_count or ""}}</output>
-{% else %}
-<output role="presentation">{{count}}</output>
-{% endif %}
-{%- endmacro -%}
-
-
-{%- macro cell_in(cell, nb, body) -%}
-{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<output name="cell_count" role="presentation" id={{ID}}/cell_count>{{count + 1}}</output>
-{%- endmacro -%}
 
 {%- macro cell_output(cell, nb, parts) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -7,50 +7,19 @@
 <meta name="color-scheme" content="dark light">
 
 <style>
-    {# use the system ui and a larger font #}
     body {
         font-size: larger;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        overflow-x: hidden;
+        padding: 0 1em 0 1em;
     }
 
-    {# use flex to display the main area. each cell will be arranged according to the flex display, grid could be used instead. using flex generates new interactive elements when horizontal or vertical scroll is required. #}
-
-    /** focus **/
-    section {
-        outline-width: .2em;
-        outline-offset: -.1em;
-    }
-
-    section:focus-within {
-        outline-style: solid;
-    }
-
-    section:hover {
-        outline-style: dotted;
-    }
-    
-    section:hover:focus-within {
-        outline-style: double;
-    }
-
-    /** layout **/
-    main>form>label>span,
+    main>form,
     fieldset[name=input]:disabled~ul[role=toolbar],
     fieldset[name=outputs]>legend,  
     form[action=markdown]+section>fieldset[name=input]:disabled,
     form+section[data-outputs="0"]>fieldset[name=outputs] {
         display: none;
-    }
-
-    body {
-        overflow-x: hidden;
-        padding: 0 1em 0 1em;
-    }
-
-    main>form {
-        float: right;
-        border-left: solid transparent;
-        padding: .5em 0 0 0;`
     }
 
     main>section {
@@ -83,7 +52,23 @@
         color: unset;
     }
 
-    /** skip links **/
+    main>section {
+        outline-width: .2em;
+        outline-offset: -.1em;
+    }
+
+    main>section:focus-within {
+        outline-style: solid;
+    }
+
+    main>section:hover {
+        outline-style: dotted;
+    }
+    
+    main>section:hover:focus-within {
+        outline-style: double;
+    }
+
     .visually-hidden:not(:focus):not(:active) {
         clip: rect(0 0 0 0);
         clip-path: inset(50%);
@@ -100,7 +85,7 @@
 {%- set tags = celltags(cell) -%}
 <form id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
     <label id={{ID}}/cell_count>
-    <span>Cell</span><output name="cell_count" title="Cell {{count + 1}}" role="presentation">{{count + 1}}</output></label>
+    Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
 </form>
 <section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}" data-outputs="{{(cell.outputs or "").__len__()}}">
     <fieldset name=input role=presentation disabled>
@@ -160,8 +145,6 @@
     -%}{{super()}}</output>{%- endblock -%}
 {%- endfor -%}
 {%- endmacro -%}
-
-
 
 {% block body_header %}
 <body>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -27,6 +27,7 @@
 
     /** layout **/
     fieldset[name=input]:disabled~ul[role=toolbar],
+    fieldset[name=outputs]>legend,  
     form[action=markdown]+section>fieldset[name=input]:disabled,
     main>section.markdown>fieldset[name=outputs]>legend+label {
         display: none;
@@ -124,7 +125,7 @@
 {% set CODE = cell.cell_type == "code" %}
 
 <fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}hidden{% endif %} {% if not CODE %}role="presentation"{% endif %}>
-    <legend id={{ID}}/execution_count hidden>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
+    <legend id={{ID}}/execution_count>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
     <label aria-hidden=true>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -1,16 +1,5 @@
 {%- extends 'semantic-forms/cell.html.j2' -%}
 
-
-
-{# cell is a tough analogy, it is an ambiguous signifier dependent on context.
-the analogy to a biologic cell asks "what is the nucleus?" or "what encodes the objective?".
-the source input feels like it is the irreducible element of our computational cells.
-lines of text evolve over time. like dna they replicate, mutate, evolve, and cooperate.
-
-allied alphabets dancing on carefully organized sand emitting waves of sound, light, and hope.
-the lines in the source, the nucleus, freeze a sliver of a movement in hypermedia.
-
-#}
 {% from 'mathjax.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
@@ -98,15 +87,7 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
         <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
     </form>
     <fieldset name=input role=presentation disabled>
-        {# its recommended to use a legend, but we want the legend to name the textarea. it makes semantic sense to use a fieldset for the input
-        
-        the visual label doubles the content of the legend, but this is similar to a recommended  pattern from https://adrianroselli.com/2022/07/use-legend-and-fieldset.html 
-        
-        with fieldset[role=presentation] and legend[hidden] the In group not announced entering the group. 
-        instead the "In" is only announced in the textarea and the visual `label` is hidden from assistive tech.
-        #}
         <legend hidden id="{{ID}}/input_count">In&nbsp;<output name="input_count" role="presentation">{{cell.execution_count or ""}}</output></legend>
-        {# semantically a label with the same contents as the legend above. it only exists for visual purposes. #}
         <label aria-hidden=true>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
         <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" aria-labelledby="{{ID}}/input_count">{{cell.source}}</textarea>
     </fieldset>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -124,7 +124,7 @@
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% set CODE = cell.cell_type == "code" %}
 
-<fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}style="display: none;"{% endif %}>
+<fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}hidden{% endif %} {% if not CODE %}role="presentation"{% endif %}>
     <legend id={{ID}}/execution_count>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -127,16 +127,15 @@
     <legend id={{ID}}/execution_count>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}
-    <output role="presentation" class="render" form={{ID}} aria-labelledby="{{ID}}/execution_count">
-    {{markdown(cell.source) | strip_files_prefix}}
-    </output>
+    <output role="presentation" class="render">{{markdown(cell.source) | strip_files_prefix}}</output>
     {% endif %}
 </fieldset>
 {%- endmacro -%}
 
 {%- macro cell_display_priority(cell, ID) -%}
 {%- for i, output in enumerate(cell.outputs) -%}
-{%- block output scoped -%}{%- block output_prompt -%}{%- endblock-%}{{super()}}{%- endblock -%}
+{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}">{%- block output_prompt -%}{%- endblock
+    -%}{{super()}}</output>{%- endblock -%}
 {%- endfor -%}
 {%- endmacro -%}
 
@@ -151,3 +150,4 @@
     </header>
     <main id="/" aria-label="{{title}}">
 {% endblock body_header %}
+

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -31,31 +31,15 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
         flex-direction: column;
     }
 
-    {# cells have labels #}
-    output[name=cell_count]:before {
-        content: "Cell ";
-    }
-
-    output[name=input_count]:before {
-        content: "In ";
-    }
-    
-    {# computational cells have extra labels #}
-    output[name=execution_count]:before {
-        content: "Out ";
-    }
-
-
     section:focus-within {
         border: 2px solid;
     }
+
     section:hover {
         outline: 2px dashed;
         outline-offset: -3px; {# border offset plus a half #}
     }
 
-    {#  #}
-    
     section > form,
     fieldset[name=input]:disabled~ul[role=toolbar], 
     section.markdown>fieldset[name=input]:disabled,
@@ -110,40 +94,17 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
 {%- set tags = celltags(cell) -%}
 <section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">
     <form id="{{ID}}" name="{{ID}}" method="POST">
-        <output name="cell_count" role="presentation" id={{ID}}/cell_count>{{count + 1}}</output>
+        <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
     </form>
     <fieldset name=input role=presentation disabled>
-        <legend>
-            <output name="input_count" role="presentation">{{cell.execution_count or ""}}</output>
-        </legend>
-        <label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}Source</label>
-        <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}">{{cell.source}}</textarea>
+        <label id="{{ID}}/input_count">In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
+        <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" aria-labelledby="{{ID}}/input_count">{{cell.source}}</textarea>
     </fieldset>
     {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     {{ cell_output(cell, nb) }}
 </section>
 {% endblock any_cell %}
 
-
-{# cell is a tough analogy, it is an ambiguous signifier dependent on context.
-the analogy to a biologic cell asks "what is the nucleus?" or "what encodes the objective?".
-the source input feels like it is the irreducible element of our computational cells.
-lines of text evolve over time. like dna they replicate, mutate, evolve, and cooperate.
-
-allied alphabets dancing on carefully organized sand emitting waves of sound, light, and hope.
-the lines in the source, the nucleus, freeze a sliver of a movement in hypermedia.
-
-#}
-{%- macro cell_textarea(cell, nb) -%}
-{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
-</label>
-<textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" readonly>{{cell.source}}</textarea>
-{%- endmacro -%}
-
-{%- macro cell_form_element(cell, nb) -%}
-{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-{%- endmacro -%}
 
 {%- macro cell_submit(cell, nb) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
@@ -193,9 +154,7 @@ of the execution count label on different elements with different roles.
 {% set CODE = cell.cell_type == "code" %}
 
 <fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}style="display: none;"{% endif %}>
-    <legend>
-        <output name="execution_count" id={{ID}}/execution_count role="presentation">{{cell.execution_count or ""}}</output>
-    </legend>
+    <legend id={{ID}}/execution_count>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}
     <output role="presentation" class="render" form={{ID}} aria-labelledby="{{ID}}/execution_count">
@@ -212,7 +171,3 @@ of the execution count label on different elements with different roles.
 {%- endfor -%}
 {%- endmacro -%}
 
-
-{%- macro highlight(body, type) -%}
-{{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
-{%- endmacro -%}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -16,16 +16,25 @@
     {# use flex to display the main area. each cell will be arranged according to the flex display, grid could be used instead. using flex generates new interactive elements when horizontal or vertical scroll is required. #}
 
     /** focus **/
+    section {
+        outline-width: .2em;
+        outline-offset: -.1em;
+    }
+
     section:focus-within {
-        border: 2px solid;
+        outline-style: solid;
     }
 
     section:hover {
-        outline: 2px dashed;
-        outline-offset: -3px; {# border offset plus a half #}
+        outline-style: dotted;
+    }
+    
+    section:hover:focus-within {
+        outline-style: double;
     }
 
     /** layout **/
+    main>form>label>span,
     fieldset[name=input]:disabled~ul[role=toolbar],
     fieldset[name=outputs]>legend,  
     form[action=markdown]+section>fieldset[name=input]:disabled,
@@ -33,37 +42,39 @@
         display: none;
     }
 
-    main {
-        display: flex;
+    body {
         overflow-x: hidden;
-        flex-direction: column;
-        margin: 1rem;
+        padding: 0 1em 0 1em;
+    }
+
+    main>form {
+        float: right;
+        border-left: solid transparent;
+        padding: .5em 0 0 0;`
     }
 
     main>section {
         display: flex;
         flex-direction: column;
         align-items: stretch;
-        gap: 1rem 1rem;
+        padding: .5em;
     }
 
-    main>section>fieldset[name=input] {
+    main>section>[name=input] {
         border: none;
     }
-   
-    fieldset[name=outputs] {
+
+    textarea[name=source], [name=outputs] {
         overflow: auto;
-        border: 0;
-        padding: 0.01em 0 0 0;
-        margin: 0;
         min-width: 0;
     }
 
-    body:not(:-moz-handler-blocked) fieldset[name=outputs] {
+    body:not(:-moz-handler-blocked) [name=outputs],
+    body:not(:-moz-handler-blocked) [name=input] {
         display: table-cell;
     }
 
-    textarea[name=source], fieldset[name$=put]>output {
+    textarea[name=source], [name=outputs]>output {
         width: 100%;
     }
 
@@ -87,8 +98,9 @@
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {%- set CODE = cell.cell_type == "code" -%}
 {%- set tags = celltags(cell) -%}
-<form hidden id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
-    <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
+<form id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
+    <label id={{ID}}/cell_count>
+    <span>Cell</span><output name="cell_count" title="Cell {{count + 1}}" role="presentation">{{count + 1}}</output></label>
 </form>
 <section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}" data-outputs="{{(cell.outputs or "").__len__()}}">
     <fieldset name=input role=presentation disabled>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -1,0 +1,190 @@
+{%- extends 'semantic-forms/cell.html.j2' -%}
+
+
+
+{# cell is a tough analogy, it is an ambiguous signifier dependent on context.
+the analogy to a biologic cell asks "what is the nucleus?" or "what encodes the objective?".
+the source input feels like it is the irreducible element of our computational cells.
+lines of text evolve over time. like dna they replicate, mutate, evolve, and cooperate.
+
+allied alphabets dancing on carefully organized sand emitting waves of sound, light, and hope.
+the lines in the source, the nucleus, freeze a sliver of a movement in hypermedia.
+
+#}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+{% block css %}
+<meta name="color-scheme" content="dark light">
+<style>
+    body {
+        font-size: larger;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    }
+
+    main {
+        display: flex;
+        overflow-x: hidden;
+        flex-direction: column;
+    }
+
+    output[name=cell_count]:before {
+        content: "Cell ";
+    }
+    output[name=execution_count]:before {
+        content: "Out ";
+    }
+
+    textarea[name=source]:read-only~ul[role=toolbar],
+    textarea[name=source]:read-only>label[for$="\/source"],
+    section.markdown>textarea[name=source],
+    section.markdown>fieldset[name=outputs] legend,
+    section.markdown output[name$=_count] {
+        display: none;
+    }
+
+    fieldset[name$=put]>output {
+        width: 100%
+    }
+
+    output[name$=_count] {
+        font-family: monospace;
+    }
+
+    main>section {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    main>section>fieldset[name=input],
+    main>section.markdown>fieldset[name=outputs] {
+        border: none;
+        display: flex;
+        flex-direction: row;
+    }
+
+    main>section {
+        overflow-x: auto;
+    }
+
+    .visually-hidden:not(:focus):not(:active) {
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+    }
+</style>{% endblock css %}
+
+{% macro input(cell, nb) %}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{{ cell_form_element(cell, nb)}}
+{{ cell_in(cell, nb) }}
+{{ cell_textarea(cell, nb) }}
+{% endmacro %}
+
+{% block any_cell scoped %}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{%- set CODE = cell.cell_type == "code" -%}
+{%- set tags = celltags(cell) -%}
+<section {% if CODE %}aria-labelledby="{{ID}}/execution_count" {% endif %}
+    class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">
+    {{ input(cell, nb) }}
+    {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
+    {{ cell_output(cell, nb) }}
+</section>
+{% endblock any_cell %}
+
+
+{# cell is a tough analogy, it is an ambiguous signifier dependent on context.
+the analogy to a biologic cell asks "what is the nucleus?" or "what encodes the objective?".
+the source input feels like it is the irreducible element of our computational cells.
+lines of text evolve over time. like dna they replicate, mutate, evolve, and cooperate.
+
+allied alphabets dancing on carefully organized sand emitting waves of sound, light, and hope.
+the lines in the source, the nucleus, freeze a sliver of a movement in hypermedia.
+
+#}
+{%- macro cell_textarea(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
+</label>
+<textarea name="source" id="{{ID}}/source" form="{{ID}}" readonly>{{cell.source}}</textarea>
+{%- endmacro -%}
+
+{%- macro cell_form_element(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<form id="{{ID}}" name="{{ID}}" method="POST"></form>
+{%- endmacro -%}
+
+{%- macro cell_submit(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{# https://www.w3.org/TR/WCAG20-TECHS/H32.html #}
+<button form="{{ID}}" type="submit" disabled aria-label="Run Cell"></button>
+{%- endmacro -%}
+
+{%- macro cell_toolbars(cell, nb, body) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<ul role="toolbar" aria-labelledby="{{ID}}/execution_count">{%- for part in body -%}<li>{{part}}</li>{%- endfor -%}</ul>
+{%- endmacro -%}
+
+{%- macro cell_type(cell, nb) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{%- set cell_type = cell.cell_type -%}
+<select name="cell_type" aria-label="Cell Type" form="{{ID}}" disabled>
+    <option {% if cell_type=="code" %}selected{% endif %} value="code">code</option>
+    <option {% if cell_type=="markdown" %}selected{% endif %} value="markdown">markdown</option>
+    <option {% if cell_type=="raw" %}selected{% endif %} value="raw">raw</option>
+    <option {% if cell_type=="unknown" %}selected{% endif %} value="unknown">unknown</option>
+</select>
+{%- endmacro -%}
+
+{# the execution count has been one of the most confusing aspects of this journey.
+it's meaning wasn't revealed until the very end of this rigorous study.
+the result discovered labelable, interactive elements that describe the components of the cell.
+assistive technology requires labels for interactive objects and the semantic representation allows the re-use
+of the execution count label on different elements with different roles.
+#}
+{%- macro cell_out(cell, nb, body) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{% if cell.cell_type == "code" %}
+<output name="execution_count" id={{ID}}/execution_count role="presentation">{{cell.execution_count or ""}}</output>
+{% else %}
+<output role="presentation">{{count}}</output>
+{% endif %}
+{%- endmacro -%}
+
+
+{%- macro cell_in(cell, nb, body) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+<output name="cell_count" role="presentation" id={{ID}}/cell_count>{{count + 1}}</output>
+{%- endmacro -%}
+
+{%- macro cell_output(cell, nb, parts) -%}
+{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
+{% set CODE = cell.cell_type == "code" %}
+<fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}style="display: none;{% endif %}>
+    <legend>{{ cell_out(cell, nb) }}</legend>
+    {{cell_display_priority(cell, ID)}}
+    {% if cell.cell_type=="markdown" %}
+    <output role="presentation" class="render" form={{ID}} aria-labelledby="{{ID}}/execution_count">
+    {{markdown(cell.source) | strip_files_prefix}}
+    </output>
+    {% endif %}
+</fieldset>
+{%- endmacro -%}
+
+{%- macro cell_display_priority(cell, ID) -%}
+{%- for i, output in enumerate(cell.outputs) -%}
+{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock
+    -%}{{super()}}</output>{%- endblock -%}
+{%- endfor -%}
+{%- endmacro -%}
+
+
+{%- macro highlight(body, type) -%}
+{{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
+{%- endmacro -%}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -29,7 +29,7 @@
     fieldset[name=input]:disabled~ul[role=toolbar],
     fieldset[name=outputs]>legend,  
     form[action=markdown]+section>fieldset[name=input]:disabled,
-    main>section.markdown>fieldset[name=outputs]>legend+label {
+    form+section[data-outputs="0"]>fieldset[name=outputs] {
         display: none;
     }
 
@@ -84,7 +84,7 @@
 <form hidden id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
     <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
 </form>
-<section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">
+<section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}" data-outputs="{{(cell.outputs or "").__len__()}}">
     <fieldset name=input role=presentation disabled>
         <legend hidden id="{{ID}}/input_count">In&nbsp;<output name="input_count" role="presentation">{{cell.execution_count or ""}}</output></legend>
         <label aria-hidden=true>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
@@ -124,14 +124,16 @@
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% set CODE = cell.cell_type == "code" %}
 
-<fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}hidden{% endif %} {% if not CODE %}role="presentation"{% endif %}>
+<fieldset name="outputs" id="{{ID}}/outputs">
+    {% if CODE and cell.outputs %}
     <legend id={{ID}}/execution_count>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
     <label aria-hidden=true>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
     {{cell_display_priority(cell, ID)}}
-    {% if cell.cell_type=="markdown" %}
-    <output role="presentation" class="render">{{markdown(cell.source) | strip_files_prefix}}</output>
     {% endif %}
 </fieldset>
+{% if cell.cell_type=="markdown" %}
+{{ markdown(cell.source) | strip_files_prefix }}
+{% endif %}
 {%- endmacro -%}
 
 {%- macro cell_display_priority(cell, ID) -%}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -14,12 +14,8 @@
     }
 
     {# use flex to display the main area. each cell will be arranged according to the flex display, grid could be used instead. using flex generates new interactive elements when horizontal or vertical scroll is required. #}
-    main {
-        display: flex;
-        overflow-x: hidden;
-        flex-direction: column;
-    }
 
+    /** focus **/
     section:focus-within {
         border: 2px solid;
     }
@@ -29,23 +25,17 @@
         outline-offset: -3px; {# border offset plus a half #}
     }
 
-    fieldset[name=input]:disabled~ul[role=toolbar] 
-    section.markdown>fieldset[name=input]:disabled,
-    section.markdown>fieldset[name=input]:disabled ~ fieldset[name=outputs] legend,
-    section.markdown output[name$=_count] {
+    /** layout **/
+    fieldset[name=input]:disabled~ul[role=toolbar],
+    form[action=markdown]+section>fieldset[name=input]:disabled,
+    form[action=markdown]+section>fieldset[name=input]:disabled~fieldset[name=outputs] legend {
         display: none;
     }
 
-    textarea[name=source]:disabled {
-        color: inherit;
-    }
-
-    textarea[name=source], fieldset[name$=put]>output {
-        width: 100%;
-    }
-
-    output[name$=_count] {
-        font-family: monospace;
+    main {
+        display: flex;
+        overflow-x: hidden;
+        flex-direction: column;
     }
 
     main>section {
@@ -62,10 +52,20 @@
         flex-direction: row;
     }
 
+    textarea[name=source], fieldset[name$=put]>output {
+        width: 100%;
+    }
+
     main>section {
         overflow-x: auto;
     }
 
+    /** fix the color constrast on disabled textareas **/
+    fieldset[name=input]:disabled>textarea {
+        color: unset;
+    }
+
+    /** skip links **/
     .visually-hidden:not(:focus):not(:active) {
         clip: rect(0 0 0 0);
         clip-path: inset(50%);
@@ -75,22 +75,22 @@
         white-space: nowrap;
         width: 1px;
     }
-
 </style>{% endblock css %}
 {% block any_cell scoped %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {%- set CODE = cell.cell_type == "code" -%}
 {%- set tags = celltags(cell) -%}
+<form hidden id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}">
+    <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
+</form>
 <section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">
-    <form id="{{ID}}" name="{{ID}}" method="POST" hidden>
-        <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
-    </form>
-    {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     <fieldset name=input role=presentation disabled>
         <legend hidden id="{{ID}}/input_count">In&nbsp;<output name="input_count" role="presentation">{{cell.execution_count or ""}}</output></legend>
         <label aria-hidden=true>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
         <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" aria-labelledby="{{ID}}/input_count">{{cell.source}}</textarea>
     </fieldset>
+    {# things need to follow this input in dom order so that we can use css selectors off fieldset:disabled #}
+    {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     {{ cell_output(cell, nb) }}
 </section>
 {% endblock any_cell %}
@@ -136,8 +136,7 @@
 
 {%- macro cell_display_priority(cell, ID) -%}
 {%- for i, output in enumerate(cell.outputs) -%}
-{%- block output scoped -%}<output role="presentation" name="outputs/{{i}}" id="{{ID}}/outputs/{{i}}" form="{{ID}}" aria-labelledby="{{ID}}/execution_count">{%- block output_prompt -%}{%- endblock
-    -%}{{super()}}</output>{%- endblock -%}
+{%- block output scoped -%}{%- block output_prompt -%}{%- endblock-%}{{super()}}{%- endblock -%}
 {%- endfor -%}
 {%- endmacro -%}
 

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -29,8 +29,7 @@
         outline-offset: -3px; {# border offset plus a half #}
     }
 
-    section > form,
-    fieldset[name=input]:disabled~ul[role=toolbar], 
+    fieldset[name=input]:disabled~ul[role=toolbar] 
     section.markdown>fieldset[name=input]:disabled,
     section.markdown>fieldset[name=input]:disabled ~ fieldset[name=outputs] legend,
     section.markdown output[name$=_count] {
@@ -83,15 +82,15 @@
 {%- set CODE = cell.cell_type == "code" -%}
 {%- set tags = celltags(cell) -%}
 <section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">
-    <form id="{{ID}}" name="{{ID}}" method="POST">
+    <form id="{{ID}}" name="{{ID}}" method="POST" hidden>
         <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
     </form>
+    {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     <fieldset name=input role=presentation disabled>
         <legend hidden id="{{ID}}/input_count">In&nbsp;<output name="input_count" role="presentation">{{cell.execution_count or ""}}</output></legend>
         <label aria-hidden=true>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
         <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" aria-labelledby="{{ID}}/input_count">{{cell.source}}</textarea>
     </fieldset>
-    {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     {{ cell_output(cell, nb) }}
 </section>
 {% endblock any_cell %}

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -16,35 +16,59 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
 
 {% block css %}
 <meta name="color-scheme" content="dark light">
+
 <style>
+    {# use the system ui and a larger font #}
     body {
         font-size: larger;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     }
 
+    {# use flex to display the main area. each cell will be arranged according to the flex display, grid could be used instead. using flex generates new interactive elements when horizontal or vertical scroll is required. #}
     main {
         display: flex;
         overflow-x: hidden;
         flex-direction: column;
     }
 
+    {# cells have labels #}
     output[name=cell_count]:before {
         content: "Cell ";
     }
+
+    output[name=input_count]:before {
+        content: "In ";
+    }
+    
+    {# computational cells have extra labels #}
     output[name=execution_count]:before {
         content: "Out ";
     }
 
-    textarea[name=source]:read-only~ul[role=toolbar],
-    textarea[name=source]:read-only>label[for$="\/source"],
-    section.markdown>textarea[name=source],
-    section.markdown>fieldset[name=outputs] legend,
+
+    section:focus-within {
+        border: 2px solid;
+    }
+    section:hover {
+        outline: 2px dashed;
+        outline-offset: -3px; {# border offset plus a half #}
+    }
+
+    {#  #}
+    
+    section > form,
+    fieldset[name=input]:disabled~ul[role=toolbar], 
+    section.markdown>fieldset[name=input]:disabled,
+    section.markdown>fieldset[name=input]:disabled ~ fieldset[name=outputs] legend,
     section.markdown output[name$=_count] {
         display: none;
     }
 
-    fieldset[name$=put]>output {
-        width: 100%
+    textarea[name=source]:disabled {
+        color: inherit;
+    }
+    textarea[name=source], fieldset[name$=put]>output {
+        width: 100%;
     }
 
     output[name$=_count] {
@@ -55,6 +79,7 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
         display: flex;
         flex-direction: column;
         align-items: stretch;
+        gap: 1rem 1rem;
     }
 
     main>section>fieldset[name=input],
@@ -78,21 +103,22 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
         width: 1px;
     }
 </style>{% endblock css %}
-
-{% macro input(cell, nb) %}
-{%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-{{ cell_form_element(cell, nb)}}
-{{ cell_in(cell, nb) }}
-{{ cell_textarea(cell, nb) }}
-{% endmacro %}
-
 {% block any_cell scoped %}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {%- set CODE = cell.cell_type == "code" -%}
 {%- set tags = celltags(cell) -%}
-<section {% if CODE %}aria-labelledby="{{ID}}/execution_count" {% endif %}
-    class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">
-    {{ input(cell, nb) }}
+<section aria-labelledby="{{ID}}/cell_count" class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}">
+    <form id="{{ID}}" name="{{ID}}" method="POST">
+        <output name="cell_count" role="presentation" id={{ID}}/cell_count>{{count + 1}}</output>
+    </form>
+    <fieldset name=input role=presentation disabled>
+        <legend>
+            <output name="input_count" role="presentation">{{cell.execution_count or ""}}</output>
+        </legend>
+        <label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
+        </label>
+        <textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" readonly>{{cell.source}}</textarea>
+    </fieldset>
     {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     {{ cell_output(cell, nb) }}
 </section>
@@ -112,12 +138,11 @@ the lines in the source, the nucleus, freeze a sliver of a movement in hypermedi
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 <label for="{{ID}}/source">{# https://www.w3.org/WAI/WCAG21/Techniques/general/G208 #}
 </label>
-<textarea name="source" id="{{ID}}/source" form="{{ID}}" readonly>{{cell.source}}</textarea>
+<textarea name="source" id="{{ID}}/source" rows="{{cell.source.splitlines().__len__()}}" form="{{ID}}" readonly>{{cell.source}}</textarea>
 {%- endmacro -%}
 
 {%- macro cell_form_element(cell, nb) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
-<form id="{{ID}}" name="{{ID}}" method="POST"></form>
 {%- endmacro -%}
 
 {%- macro cell_submit(cell, nb) -%}
@@ -166,8 +191,11 @@ of the execution count label on different elements with different roles.
 {%- macro cell_output(cell, nb, parts) -%}
 {%- set count = nb["cells"].index(cell)-%}{%- set ID = "/cells/" + str(count) -%}
 {% set CODE = cell.cell_type == "code" %}
-<fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}style="display: none;{% endif %}>
-    <legend>{{ cell_out(cell, nb) }}</legend>
+
+<fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}style="display: none;"{% endif %}>
+    <legend>
+        <output name="execution_count" id={{ID}}/execution_count role="presentation">{{cell.execution_count or ""}}</output>
+    </legend>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}
     <output role="presentation" class="render" form={{ID}} aria-labelledby="{{ID}}/execution_count">

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -27,7 +27,8 @@
 
     /** layout **/
     fieldset[name=input]:disabled~ul[role=toolbar],
-    form[action=markdown]+section>fieldset[name=input]:disabled {
+    form[action=markdown]+section>fieldset[name=input]:disabled,
+    main>section.markdown>fieldset[name=outputs]>legend+label {
         display: none;
     }
 
@@ -124,7 +125,7 @@
 
 <fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}hidden{% endif %} {% if not CODE %}role="presentation"{% endif %}>
     <legend id={{ID}}/execution_count hidden>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
-    <label {% if not CODE %}hidden{% endif %} aria-hidden=true>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
+    <label aria-hidden=true>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}
     <output role="presentation" class="render">{{markdown(cell.source) | strip_files_prefix}}</output>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -123,7 +123,8 @@
 {% set CODE = cell.cell_type == "code" %}
 
 <fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}hidden{% endif %} {% if not CODE %}role="presentation"{% endif %}>
-    <legend id={{ID}}/execution_count {% if not CODE %}hidden{% endif %}>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
+    <legend id={{ID}}/execution_count hidden>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
+    <label aria-hidden=true>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}
     <output role="presentation" class="render">{{markdown(cell.source) | strip_files_prefix}}</output>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -124,7 +124,7 @@
 
 <fieldset name="outputs" id="{{ID}}/outputs" {% if CODE and not cell.outputs %}hidden{% endif %} {% if not CODE %}role="presentation"{% endif %}>
     <legend id={{ID}}/execution_count hidden>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
-    <label aria-hidden=true>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
+    <label {% if not CODE %}hidden{% endif %} aria-hidden=true>Out&nbsp;<output name="execution_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
     {{cell_display_priority(cell, ID)}}
     {% if cell.cell_type=="markdown" %}
     <output role="presentation" class="render">{{markdown(cell.source) | strip_files_prefix}}</output>

--- a/nbconvert_html5/templates/semantic-forms/static/script.js
+++ b/nbconvert_html5/templates/semantic-forms/static/script.js
@@ -114,12 +114,12 @@ window.addEventListener('load', function () {
     slider.addEventListener("input", (event) => {
         var id = `#/cells/${event.target.value}`;
         event.target.nextElementSibling.value = event.target.value;
-        document.getElementById(id.substring(1)).scrollIntoView();
     });
 
     // the cell slider updates the page history
     slider.addEventListener("change", (event) => {
         var id = `#/cells/${event.target.value}`;
+        document.getElementById(id.substring(1)).scrollIntoView();
         history.replaceState({}, `Cell ${event.target.value}`, id);
     })
 

--- a/nbconvert_html5/templates/semantic-forms/static/style.css
+++ b/nbconvert_html5/templates/semantic-forms/static/style.css
@@ -40,28 +40,25 @@ main>header details.nav {
 main>header {
     overflow: auto;
     opacity: .9;
-    position: sticky;
-    top: 0;
-    max-height: 100vh;
 }
 
-main > table.cells > thead {
+main > .cells > thead {
     display: none;
 }
 
-.static td.execution_count label:not(:empty):before {
+.static .execution_count label:not(:empty):before {
     content: "In: ";
 }
 
-table.cells {
+.cells {
     width: 100%;
 }
 
-tr.cell {
+.cell {
     display: grid;
 }
 
-tr.code.cell {
+.code.cell {
     grid-template-rows: 2rem 1rem auto auto;
     grid-template-columns: 5fr 95fr;
     justify-items: start;
@@ -71,22 +68,22 @@ tr.code.cell {
     width: 95vw;
 }
 
-tr.markdown.cell {
+.markdown.cell {
     grid-template-columns: 95fr 5fr;
     grid-template-areas: "source toolbar";
 }
 
-tr.cell>td.source {
+textarea.source {
     grid-area: source;
     width: 100%;
     overflow-x: auto;
 }
 
-tr.cell>td.cell_type {
+.cell>.cell_type {
     grid-area: cell_type;
 }
 
-tr.cell>td.outputs {
+.cell>.outputs {
     overflow-x: auto;
     grid-area: outputs;
     display: flex;
@@ -94,28 +91,29 @@ tr.cell>td.outputs {
     width: 100%;
 }
 
-tr.cell>td.toolbar {
+.cell>.toolbar {
     grid-area: toolbar;
 }
 
-tr.cell>td.execution_count {
+.cell>.execution_count {
     grid-area: execution_count;
 }
 
-td.source form textarea {
+textarea.source {
     width: 100%;
 }
 
-td.cell_type,
-tr.cell form label.cell_type,
-tr.markdown.cell td.outputs,
-tr.markdown.cell td.execution_count,
-.static td.toolbar,
+.cell_type,
+.cell label.cell_type,
+.markdown.cell .outputs,
+.markdown.cell .execution_count,
+.static .toolbar,
 .static input.run,
-.static tr.markdown.cell td.source form textarea {
+.static .markdown.cell textarea.source,
+.markdown fieldset.outputs {
     display: none;
 }
 
-td.source form textarea:focus~.render {
+.cell textarea.source:focus~.render {
     display: none;
 }

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -1,136 +1,46 @@
-{%- extends 'semantic-forms/base.html.j2' -%}
+{%- extends 'semantic-forms/index.html.j2' -%}
 {% from 'mathjax.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
-{%- block header -%}
-<!DOCTYPE html>
-<html lang="en">
 
-<head>
-    {%- block html_head -%}
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | escape_html %}
-    <title>{{nb_title}}</title>
-    <meta name="color-scheme" content="light">
-    <meta name="description" content="">
-
-
-    {% block jupyter_widgets %}
-    {%- if "widgets" in nb.metadata -%}
-    <script src="{{ resources.require_js_url }}"></script>
-    {{ jupyter_widgets(resources.jupyter_widgets_base_url, resources.html_manager_semver_range,
-    resources.widget_renderer_url) }}
-    {%- endif -%}
-    {% endblock jupyter_widgets %}
-
-    {% block extra_css %}
-    {% endblock extra_css %}
-
-    {% for css in resources.inlining.css -%}
-    <style type="text/css">{{css}}</style>
-    {% endfor %}
-
-    {% block notebook_css %}
-    {{ resources.include_css("semantic-forms/static/style.css") }}
-    {% endblock notebook_css %}
-    
-    {%- block html_head_js_mathjax -%}
-    {{ mathjax(resources.mathjax_url) }}
-    {%- endblock html_head_js_mathjax -%}
-
-    {%- endblock html_head -%}
-</head>
-{%- endblock header -%}
+{% block body_loop %}
+<table class="notebook cells" aria-label="cells" aria-rowcount="{{len(nb.cells)}}">
+    <colgroup>
+        <col class="execution_count">
+        <col class="source">
+        <col class="outputs">
+        <col class="cell_type">
+        <col class="metadata">
+        <col class="toolbar">
+    </colgroup>
+    <thead>
+        <tr class="cell">
+            <th scope="col">execution count</th>
+            <th scope="col">source</th>
+            <th scope="col">outputs</th>
+            <th scope="col">cell type</th>
+            <th scope="col">metadata</th>
+            <th scope="col">toolbar</th>
+        </tr>
+    </thead>
+    <tbody id="/cells">
+    {{super()}}
+    </tbody>
+    <tfoot>
+        <td class="execution count"></td>
+        <td class="source"></td>
+        <td class="outputs"></td>
+        <td class="cell type"></td>
+        <td class="metadata"></td>
+        <td class="toolbar"></td>
+    </tfoot>
+</table>
+{% endblock body_loop %}
 
 
-
-
-{%- block body_header -%}
-
-<body>
-    <header class="site">
-        <a class="visually-hidden" tabindex="0" href="#/cells">Skip to Main Content</a>
-        <a class="visually-hidden" tabindex="0" href="#site-settings-summary">Skip to Accessibility Settings</a>
-        <!-- search and site navigation would go here -->
-        <!-- links go to the original content -->
-    </header>
-    <main class="notebook static" aria-label="notebook" id="nb-main">
-        <header class="notebook" id="nb-header">
-            <details id="nb-nav" class="nav">
-                <summary id="nb-nav-summary"><span id="nb-nav-summary-name">{{resources.metadata.name}}.ipynb</span>
-                    Navigation</summary>
-                <form id="nb-nav-cells">
-                    <label for="nb-nav-cells-widget">Navigate to Cell</label>
-                    <input type="range" id="nb-nav-cells-widget" value="1" min="1" max="{{len(nb.cells)+1}}">
-                    <output></output>
-                </form>
-                <nav></nav>
-            </details>
-        </header>
-        <table class="notebook cells" aria-label="cells" aria-rowcount="{{len(nb.cells)}}">
-            <colgroup>
-                <col class="execution_count">
-                <col class="source">
-                <col class="outputs">
-                <col class="cell_type">
-                <col class="metadata">
-                <col class="toolbar">
-            </colgroup>
-            <thead>
-                <tr class="cell">
-                    <th scope="col">execution count</th>
-                    <th scope="col">source</th>
-                    <th scope="col">outputs</th>
-                    <th scope="col">cell type</th>
-                    <th scope="col">metadata</th>
-                    <th scope="col">toolbar</th>
-                </tr>
-            </thead>
-            <tbody id="/cells">
-                {%- endblock body_header -%}
-                {% block body_loop %}
-                {% for cell in nb.cells %}
-                {% block anycell scoped %}
-                {{cell_row(cell, nb, resources)}}
-                {% endblock anycell %}
-                {% endfor %}
-                {% endblock body_loop %}
-                {%- block body_footer -%}
-            </tbody>
-            <tfoot>
-                <td class="execution count"></td>
-                <td class="source"></td>
-                <td class="outputs"></td>
-                <td class="cell type"></td>
-                <td class="metadata"></td>
-                <td class="toolbar"></td>
-            </tfoot>
-        </table>
-        <footer id="nb-footer" class="notebook">
-            <details id="nb-metadata">
-                <summary>Metadata</summary>
-                <script id="/metadata" type="application/json">{{json.dumps(nb.metadata, indent=2)}}</script>
-            </details>
-        </footer>
-    </main>
-    <footer id="site-footer">
-        <!-- legal goes here -->
-        <details id="site-settings">
-            <summary id="site-settings-summary">Site Accessibility Settings</summary>
-        </details>
-    </footer>
-</body>
-{%- endblock body_footer -%}
-
-{% block footer %}
-{% block footer_js %}
-{{resources.include_js("semantic-forms/static/script.js")}}
-{% endblock footer_js %}
-{{ super() }}
-
-</html>
-{% endblock footer %}
+{% block any_cell %}
+{{cell_row(cell, nb, resources)}}
+{% endblock any_cell %}
 
 {% macro highlight(body, type) %}
 {{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
@@ -177,11 +87,11 @@
     <textarea readonly class="visually-hidden" name="source" id="{{ID}}-source" aria-hidden="false" autocomplete="off"
         autocorrect="off" placeholder="" spellcheck="default" rows="{{len(source.rstrip().splitlines())}}"
         aria-labelledby="{{ID}}-exec" wrap="soft">{{source}}</textarea>
-    <div class="render" role="document" aria-hidden="{% if cell.cell_type == "markdown" %}false{% else %}true{% endif
+    <output class="render" for="{{ID}}-source" aria-hidden="{% if cell.cell_type == "markdown" %}false{% else %}true{% endif
         %}">
         {% if cell.cell_type=="markdown" %}{{markdown(cell.source) | strip_files_prefix}}{% endif %}
         {% if cell.cell_type=="code" %}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% endif %}
-    </div>
+    </output>
 </form>
 {% endmacro %}
 

--- a/nbconvert_html5/templates/semantic-forms/ul.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/ul.html.j2
@@ -1,0 +1,13 @@
+{%- extends 'semantic-forms/index.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+{% block body_loop %}
+<ul>{{super()}}</ul>
+{% endblock body_loop %}
+
+{% block any_cell %}
+<li class="cell {{cell.cell_type}} {{celltags(cell)}}">
+{{cell_form(cell, nb)}}
+</li>
+{% endblock any_cell %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ configurations = [
     # "tests/configurations/tab-to-code-nav-high-contrast.py",
     "tests/configurations/table-default.py",
     "tests/configurations/sections.py",
+    "tests/configurations/smol.py",
     "tests/configurations/ol.py",
     "tests/configurations/ul.py",
     "tests/configurations/feed.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,12 +130,13 @@ notebooks = [
     "user-tests/2-content/Imaging_Sky_Background_Estimation.ipynb",
 ]
 configurations = [
-    "tests/configurations/default.py",
-    "tests/configurations/contenteditable-code.py",
-    "tests/configurations/tabs-scroll-to-top.py",
-    "tests/configurations/tab-to-content-nav-high-contrast.py",
-    "tests/configurations/tab-to-code-nav-high-contrast.py",
+    # "tests/configurations/default.py",
+    # "tests/configurations/contenteditable-code.py",
+    # "tests/configurations/tabs-scroll-to-top.py",
+    # "tests/configurations/tab-to-content-nav-high-contrast.py",
+    # "tests/configurations/tab-to-code-nav-high-contrast.py",
     "tests/configurations/table-default.py",
+    # "tests/configurations/notebook-list.py",
 ]
 
 [tool.doit.tasks.convert]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,12 +130,16 @@ notebooks = [
     "user-tests/2-content/Imaging_Sky_Background_Estimation.ipynb",
 ]
 configurations = [
-    # "tests/configurations/default.py",
+    "tests/configurations/default.py",
     # "tests/configurations/contenteditable-code.py",
-    # "tests/configurations/tabs-scroll-to-top.py",
+    "tests/configurations/tabs-scroll-to-top.py",
     # "tests/configurations/tab-to-content-nav-high-contrast.py",
     # "tests/configurations/tab-to-code-nav-high-contrast.py",
     "tests/configurations/table-default.py",
+    "tests/configurations/sections.py",
+    "tests/configurations/ol.py",
+    "tests/configurations/ul.py",
+    "tests/configurations/feed.py",
     # "tests/configurations/notebook-list.py",
 ]
 

--- a/tests/configurations/feed.py
+++ b/tests/configurations/feed.py
@@ -1,0 +1,6 @@
+"""export notebooks as a feed of articles"""
+
+c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
+c.NbConvertApp.export_format = "html5"
+c.CSSHTMLHeaderPreprocessor.style = "default"
+c.TemplateExporter.template_file = "semantic-forms/feed.html.j2"

--- a/tests/configurations/ol.py
+++ b/tests/configurations/ol.py
@@ -1,0 +1,6 @@
+"""export notebooks as an order list of forms"""
+
+c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
+c.NbConvertApp.export_format = "html5"
+c.CSSHTMLHeaderPreprocessor.style = "default"
+c.TemplateExporter.template_file = "semantic-forms/ol.html.j2"

--- a/tests/configurations/sections.py
+++ b/tests/configurations/sections.py
@@ -1,0 +1,6 @@
+"""export notebooks as regions of forms"""
+
+c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
+c.NbConvertApp.export_format = "html5"
+c.CSSHTMLHeaderPreprocessor.style = "default"
+c.TemplateExporter.template_file = "semantic-forms/sections.html.j2"

--- a/tests/configurations/smol.py
+++ b/tests/configurations/smol.py
@@ -1,0 +1,6 @@
+"""the smallest interface without fancy things"""
+
+c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
+c.NbConvertApp.export_format = "html5"
+c.CSSHTMLHeaderPreprocessor.style = "default"
+c.TemplateExporter.template_file = "semantic-forms/smol.html.j2"

--- a/tests/configurations/ul.py
+++ b/tests/configurations/ul.py
@@ -1,0 +1,6 @@
+"""export notebooks as an unordered list of forms"""
+
+c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
+c.NbConvertApp.export_format = "html5"
+c.CSSHTMLHeaderPreprocessor.style = "default"
+c.TemplateExporter.template_file = "semantic-forms/ul.html.j2"


### PR DESCRIPTION
this pull request began as an exploration of potential configurations for an accessible cell form. 

* the cell is significant enough feature to be a landmark.
* the cell has a `form`
* the cell has input and output regions
* the cell complies with web accessibility guidelines

the implementation uses semantic elements. Another implementation could use the implicit roles and proper ARIA to create an explicit accessible experience. features will need to be added and they should include accessible elements that are prescribed by references like [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/)

example outputs below:

* https://iota-school.github.io/notebooks-for-all/branch/extent/exports/html/stsci_example_notebook-smol.html
* https://iota-school.github.io/notebooks-for-all/branch/extent/exports/html/Imaging_Sky_Background_Estimation-smol.html
* https://iota-school.github.io/notebooks-for-all/branch/extent/exports/html/lorenz-executed-smol.html

this work includes testing on NVDA, VoiceOver, Orca, and ChromeVox.

## the cell landmark

the cell is a landmark with `role=region` when there is an ARIA tag. an implementation would choose whether some, all, or none of the cells are labeled.

## the cell form

the cell `form` is an empty element. all the content exists outside the `form` to allow other `form`s; `form` elements cannot be nested. to tether a cell's form associated elements to. the `document.forms` object provides nominal and ordinal access to each form.

## the cell input region

the cell input `fieldset` has an implicit `role=group`. the `disabled` attribute applies to all form descendants. a static, resting cell then is `<fieldset disabled>` which allows for custom styling based on state.

## the cell output region

the cell output holds computed values from the `input`. we represent these with the `output` tag which implicitly is an aria live element. instead we apply `role=presentation` to reduce the screen verbosity.

## the id patterns

a notebook is data and a document. we use a consistent json pointer naming convention that would provide consistent access to either the json document or html document.

## styling

styling is a non-goal of this pull request it uses minimum styling to convey the message of the notebook. we do demonstrate how semantic css selectors naturally facilitate formatting the document. using flex box will help with reactive experiences at high zoom magnifications.

## references

* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/general-principles.html
  * use `aside` for footnotes

### `output`

* https://www.scottohara.me/blog/2019/07/10/the-output-element.html
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section

### `fieldset` 

* https://adrianroselli.com/2022/07/use-legend-and-fieldset.html
* https://www.tpgi.com/fieldsets-legends-and-screen-readers-again/
