### PR TITLE
apply a feed pattern to our current semantics.

### DIFF
--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -25,8 +25,9 @@
         padding-right: 16px;
     }
 
-    label[id$=\/cell_count],    
+    label[id$=\/form_label],    
     fieldset[name=input]:disabled~ul[role=toolbar],
+    fieldset[name=input]>legend,  
     fieldset[name=outputs]>legend,  
     article>form[action=markdown]~fieldset[name=input]:disabled,
     article[data-outputs="0"]>fieldset[name=outputs] {
@@ -40,7 +41,7 @@
         padding: var(--cell-padding);
     }
 
-    main>article>[name=input] {
+    [role=feed]>article>[name=input] {
         border: none;
     }
 
@@ -102,12 +103,12 @@
     data-sloc="{{ct.sloc}}" data-outputs="{{(cell.outputs or "").__len__()}}"
     aria-labelledby={{ID}}/cell_count
     aria-posinset="{{count + 1}}" aria-setsize="{{nb.cells.__len__()}}">
-    <form id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
+    <form id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/form_label>
     </form>
-    <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
+    <label id={{ID}}/form_label>{{cell.cell_type}}<span>Cell</span><output id={{ID}}/cell_count name="cell_count" role="presentation">{{count + 1}}</output></label>
     <a aria-hidden="true" href="#{{count + 1}}" tabindex="-1" alt="Cell {{count + 1}}" title="Cell {{count + 1}}">{{count + 1}}</a>
     <fieldset name=input role=presentation disabled>
-        <legend hidden id="{{ID}}/input_count">In&nbsp;<output name="input_count" role="presentation">{{cell.execution_count or ""}}</output></legend>
+        <legend id={{ID}}/input_count>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></legend>
         <label aria-hidden=true>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
         <textarea name="source" id="{{ID}}/source" rows="{{ct.loc}}" form="{{ID}}" aria-labelledby="{{ID}}/input_count">{{cell.source}}</textarea>
     </fieldset>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -101,7 +101,7 @@
 <article {% if not ct.sloc and not cell.outputs %}role="separator"{% endif %}
     class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}" 
     data-sloc="{{ct.sloc}}" data-outputs="{{(cell.outputs or "").__len__()}}"
-    aria-labelledby={{ID}}/cell_count
+    aria-labelledby={{ID}}/form_label
     aria-posinset="{{count + 1}}" aria-setsize="{{nb.cells.__len__()}}">
     <form id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/form_label>
     </form>

--- a/nbconvert_html5/templates/semantic-forms/smol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/smol.html.j2
@@ -18,29 +18,29 @@
         padding: 0 2em 0 2em;
     }
 
-    section>a {
+    article>a {
         right: 0;
         position: absolute;
         padding-top: var(--cell-padding);
         padding-right: 16px;
     }
 
-    main>form,
+    label[id$=\/cell_count],    
     fieldset[name=input]:disabled~ul[role=toolbar],
     fieldset[name=outputs]>legend,  
-    form[action=markdown]+section>fieldset[name=input]:disabled,
-    form+section[data-outputs="0"]>fieldset[name=outputs] {
+    article>form[action=markdown]~fieldset[name=input]:disabled,
+    article[data-outputs="0"]>fieldset[name=outputs] {
         display: none;
     }
 
-    main>section {
+    main>[role=feed]>article {
         display: flex;
         flex-direction: column;
         align-items: stretch;
         padding: var(--cell-padding);
     }
 
-    main>section>[name=input] {
+    main>article>[name=input] {
         border: none;
     }
 
@@ -63,20 +63,20 @@
         color: unset;
     }
 
-    main>section {
+    [role=feed]>article {
         outline-width: var(--focus-width);
         outline-offset: calc(-1 - var(--focus-width));
     }
 
-    main>section:focus-within {
+    [role=feed]>article:focus-within {
         outline-style: solid;
     }
 
-    main>section:hover {
+    [role=feed]>article:hover {
         outline-style: dotted;
     }
     
-    main>section:hover:focus-within {
+    [role=feed]>article:hover:focus-within {
         outline-style: double;
     }
 
@@ -96,14 +96,16 @@
 {%- set tags = celltags(cell) -%}
 {%- set ct = namespace(sloc=0, loc=0)%}
 {% for line in "".join(cell.source).splitlines() %}{% set ct.loc = ct.loc + 1 %}{% if line.strip() %}{% set ct.sloc = ct.sloc + 1 %}{% endif %}{% endfor %}
-<form id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
-    <label id={{ID}}/cell_count>
-    Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
-</form>
 {% if cell.cell_type == "raw" %}{{cell.source}}{% endif %}
-<section aria-labelledby="{{ID}}/cell_count" {% if not ct.sloc and not cell.outputs %}role="separator"{% endif %}
-    class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}" data-sloc="{{ct.sloc}}" data-outputs="{{(cell.outputs or "").__len__()}}">
-    <a aria-hidden="true" href="#{{count + 1}}" alt="Cell {{count + 1}}" title="Cell {{count + 1}}">{{count + 1}}</a>
+<article {% if not ct.sloc and not cell.outputs %}role="separator"{% endif %}
+    class="cell {{cell.cell_type}}{% if tags %} {{tags}}{% endif %}" id="{{count}}" 
+    data-sloc="{{ct.sloc}}" data-outputs="{{(cell.outputs or "").__len__()}}"
+    aria-labelledby={{ID}}/cell_count
+    aria-posinset="{{count + 1}}" aria-setsize="{{nb.cells.__len__()}}">
+    <form id="{{ID}}" name="{{ID}}" method="POST" action="{{cell.cell_type}}" aria-labelledby={{ID}}/cell_count>
+    </form>
+    <label id={{ID}}/cell_count>Cell&nbsp;<output name="cell_count" role="presentation">{{count + 1}}</output></label>
+    <a aria-hidden="true" href="#{{count + 1}}" tabindex="-1" alt="Cell {{count + 1}}" title="Cell {{count + 1}}">{{count + 1}}</a>
     <fieldset name=input role=presentation disabled>
         <legend hidden id="{{ID}}/input_count">In&nbsp;<output name="input_count" role="presentation">{{cell.execution_count or ""}}</output></legend>
         <label aria-hidden=true>In&nbsp;<output name="input_count"  role="presentation">{{cell.execution_count or ""}}</output></label>
@@ -112,7 +114,7 @@
     {# things need to follow this input in dom order so that we can use css selectors off fieldset:disabled #}
     {{ cell_toolbars(cell, nb, [cell_submit(cell, nb), cell_type(cell, nb)]) }}
     {{ cell_output(cell, nb) }}
-</section>
+</article>
 {% endblock any_cell %}
 
 
@@ -169,6 +171,11 @@
         <label id="title" aria-hidden="true">{{title}}</label>
         {% block skip_links %}<a class="visually-hidden" tabindex="0" href="#/">Skip to content</a>{% endblock skip_links %}
     </header>
-    <main id="/" aria-label="{{title}}">
+    <main id="/" aria-labelledby=title>
+        <section role=feed aria-setsize={{nb.cells.__len__()}} aria-label="Cells">
 {% endblock body_header %}
 
+{% block body_footer %}
+</section>
+{{super()}}
+{% endblock body_footer %}


### PR DESCRIPTION
we've learned that cell numbers are important to connect the visual and audible experience with a notebook. a really frustrating part about this effort has been finding canonical attributes for the cell numbers. 

this modification addresses some of this frustration:
* introduces the feed pattern inside the main documents
* uses form landmarks instead of region landmarks
* puts the form inside an article. now a cell is `main>[role=feed]>article>form~*`
* introduces `aria-setsize aria-posinset` as positional descriptors.

> The feature that most distinguishes feed from other ARIA patterns that support loading data as users scroll, e.g., a [grid](https://www.w3.org/WAI/ARIA/apg/patterns/grid/), is that a feed is a structure, not a widget. Consequently, assistive technologies with a reading mode, such as screen readers, default to reading mode when interacting with feed content.
>> [Feed Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/feed/)

the notebook cells are simultaneously interactive widgets and readable objects. the feed pattern complements the interactive form pattern we've been using by explicitly defining a reading mode for the notebook document.

assistive tech users can navigate the forms in the landmark. the article and forms share a label, but the article will not announced in reading mode. the lack of duplication of the article label is the feature that allows us to connect the forms with feed pattern.