### PR TITLE
Main template layout

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from functools import partial
 import warnings
 from sys import executable
+
 HERE = Path(__file__).parent
 
 DOCS = Path("docs")
@@ -20,23 +21,47 @@ AUDITS = EXPORTS / "audits"
 REPORTS = EXPORTS / "reports"
 TEMPLATES = Path("nbconvert_html5/templates/semantic-forms")
 
+
 def do(cmd, *args):
     from doit.cmd_base import CmdAction
     from shlex import split
+
     return CmdAction(split(cmd) + list(args), shell=False)
 
-def cp(x , y):
+
+def cp(x, y):
     x, y = map(Path, (x, y))
     if x.is_dir():
-        print(F"copy {x} to {y}")
+        print(f"copy {x} to {y}")
         copytree(x, y, dirs_exist_ok=True)
     else:
-        print(F"copy {x} to {y}")
         Path.mkdir(y.parent, parents=True, exist_ok=True)
         copyfile(x, y)
 
 
+def task_styles():
+    def get_pygments(target, theme):
+        import pygments.formatters
 
+        target.write_text(
+            pygments.formatters.get_formatter_by_name(
+                "html", style=f"a11y-high-contrast-{theme}"
+            ).get_style_defs()
+        )
+
+    for theme in ("light", "dark"):
+        name = f"{theme}-code"
+        target = (TEMPLATES / name).with_suffix(".css")
+        yield dict(
+            name=f"{theme}-code",
+            targets=[target],
+            actions=[(get_pygments, (target, theme))],
+            uptodate=[target.exists],
+            clean=True,
+        )
+
+
+@create_after("styles")
 @task_params(
     [
         dict(name="notebooks", default=[TESTS / "notebooks/lorenz.ipynb"], type=list),
@@ -52,25 +77,27 @@ def task_copy(notebooks, configurations, target):
     configurations = list(map(Path, configurations))
     styles = list(TEMPLATES.glob("*.css"))
     targets = [NB / x.name for x in notebooks]
+
     def readme(target, ext, title):
-        body = F"""# {title}\n\n"""
-        for t in target.glob(F"*.{ext}"):
-            body += F"* [{t.name}]({t.relative_to(target)})\n"
+        body = f"""# {title}\n\n"""
+        for t in target.glob(f"*.{ext}"):
+            body += f"* [{t.name}]({t.relative_to(target)})\n"
         (target / "README.md").write_text(body)
 
     yield dict(
         name="notebooks",
         clean=True,
-        actions=[(cp, (x, NB /x.name )) for x in notebooks],
+        actions=[(cp, (x, NB / x.name)) for x in notebooks],
         targets=targets,
-        uptodate=list(map(Path.exists, targets))
+        uptodate=list(map(Path.exists, targets)),
     )
     yield dict(
         name="styles",
         clean=True,
-        actions=[(cp, (x, HTML /x.name )) for x in styles],
-        targets=[HTML /x.name  for x in styles],
-        uptodate=list(map(Path.exists, targets))
+        task_dep=["styles"],
+        actions=[(cp, (x, HTML / x.name)) for x in styles],
+        targets=[HTML / x.name for x in styles],
+        uptodate=list(map(Path.exists, targets)),
     )
     targets = [CONFIGS / x.name for x in configurations]
     yield dict(
@@ -78,21 +105,21 @@ def task_copy(notebooks, configurations, target):
         clean=True,
         actions=[(cp, (x, CONFIGS / x.name)) for x in configurations],
         targets=[CONFIGS / x.name for x in configurations],
-        uptodate=list(map(Path.exists, targets))
+        uptodate=list(map(Path.exists, targets)),
     )
     yield dict(
         name="readme-nb",
         actions=[(readme, (NB, "ipynb", "reference notebooks"))],
         file_dep=targets,
         clean=True,
-        targets=[NB / "README.md"]
+        targets=[NB / "README.md"],
     )
     yield dict(
         name="readme-config",
         actions=[(readme, (CONFIGS, "py", "configuration files"))],
         file_dep=targets,
         clean=True,
-        targets=[CONFIGS / "README.md"]
+        targets=[CONFIGS / "README.md"],
     )
     # this is missing the file_deps and targets
     # they can be computed
@@ -104,10 +131,12 @@ def task_copy(notebooks, configurations, target):
         yield dict(
             name=d,
             actions=[(cp, (DIR, EXPORTS / DIR))],
-            clean=[F"""rm -rf {EXPORTS / DIR}"""],
+            clean=[f"""rm -rf {EXPORTS / DIR}"""],
             file_dep=files,
-            targets=targets
+            targets=targets,
         )
+
+
 # @task_params(
 #     [
 #         dict(name="notebooks", default=[TESTS / "notebooks/lorenz.ipynb"], type=list),
@@ -200,6 +229,7 @@ def task_copy(notebooks, configurations, target):
 
 #     yield dict(name=f"index", file_dep=audits, targets=[INDEX], actions=[get_index], clean=True)
 
+
 @create_after("copy")
 @task_params(
     [
@@ -211,11 +241,13 @@ def task_copy(notebooks, configurations, target):
 def task_convert(notebooks_dir, configs_dir, target):
     """convert notebooks and configurations to their html outputs"""
     target = Path(target)
+
     def readme(target):
         body = """# html versions\n\n"""
         for t in target.glob("*.html"):
-            body += F"* [{t.name}]({t.relative_to(target)})\n"
+            body += f"* [{t.name}]({t.relative_to(target)})\n"
         (target / "README.md").write_text(body)
+
     targets = []
     for c in Path(configs_dir).glob("*.py"):
         for nb in Path(notebooks_dir).glob("*.ipynb"):
@@ -225,83 +257,80 @@ def task_convert(notebooks_dir, configs_dir, target):
             yield dict(
                 name=str(name),
                 actions=[
-                    do(f"{executable} -m jupyter nbconvert --config {c} --output {name} --output-dir {target} {nb}")
+                    do(
+                        f"{executable} -m jupyter nbconvert --config {c} --output {name} --output-dir {target} {nb}"
+                    )
                 ],
                 file_dep=[nb, c],
                 targets=[t],
                 clean=True,
-                basename="convert"
+                basename="convert",
             )
     yield dict(
         name="readme",
         actions=[(readme, (target,))],
         file_dep=targets,
-        targets=[target / "README.md"]
+        targets=[target / "README.md"],
     )
-    
+
+
 @create_after(executed="convert", creates=["audit"])
 @task_params(
     [
         dict(name="html_dir", default=HTML, type=str),
-        dict(name="target", default=AUDITS, type=str, help="the subdirectory to place audits in")
+        dict(name="target", default=AUDITS, type=str, help="the subdirectory to place audits in"),
     ]
 )
 def task_audit(html_dir, target):
     """audit the files in the html directory"""
+
     def readme(target):
         body = """# audits\n\n"""
         for t in target.glob("*.json"):
-            body += F"* [{t.name}]({t.relative_to(target)})\n"
+            body += f"* [{t.name}]({t.relative_to(target)})\n"
         (target / "README.md").write_text(body)
 
     from nbconvert_html5.audit import audit_one
+
     targets = []
     for x in Path(html_dir).rglob("*.html"):
         targets.append(Path(target) / x.with_suffix(".json").name)
         yield dict(
             name=x.name,
-            actions=[
-                (audit_one, (x, targets[-1]))
-            ],
+            actions=[(audit_one, (x, targets[-1]))],
             file_dep=[x],
             targets=[targets[-1]],
             clean=True,
-            basename="audit"
+            basename="audit",
         )
     yield dict(
         name="readme",
         actions=[(readme, (target,))],
         file_dep=targets,
-        targets=[target / "README.md"]
+        targets=[target / "README.md"],
     )
+
 
 @create_after(executed="audit")
 def task_report():
     print((HERE / "tests/templates/report.py").exists())
     TPL = HERE / "tests/templates/report.py"
-    report = module_from_spec(
-        spec_from_file_location("test.templates.report", TPL)
-    )
+    report = module_from_spec(spec_from_file_location("test.templates.report", TPL))
     report.__loader__.exec_module(report)
-    
+
     yield dict(
         name="readme",
         actions=[report.write_experiments],
         clean=True,
-        targets=[REPORTS / "experiment.md"]
+        targets=[REPORTS / "experiment.md"],
     )
     yield dict(
-        name="nb",
-        actions=[report.write_notebooks],
-        clean=True,
-        targets=[REPORTS / "notebooks.md"]
+        name="nb", actions=[report.write_notebooks], clean=True, targets=[REPORTS / "notebooks.md"]
     )
     yield dict(
-        name="configs",
-        actions=[report.write_configs],
-        clean=True,
-        targets=[REPORTS / "configs.md"]
+        name="configs", actions=[report.write_configs], clean=True, targets=[REPORTS / "configs.md"]
     )
+
 
 # @create_after(executed="audit", creates=["docs"])
 # @task_params(

--- a/dodo.py
+++ b/dodo.py
@@ -44,7 +44,11 @@ def task_styles():
         import pygments.formatters
 
         target.write_text(
-            pygments.formatters.get_formatter_by_name(
+            """body {
+                background-color: var(--nb-background-color-%s);
+                color-scheme: %s;
+            }\n""" % (theme, theme)
+            + pygments.formatters.get_formatter_by_name(
                 "html", style=f"a11y-high-contrast-{theme}"
             ).get_style_defs()
         )

--- a/dodo.py
+++ b/dodo.py
@@ -18,6 +18,7 @@ CONFIGS = EXPORTS / "configs"
 HTML = EXPORTS / "html"
 AUDITS = EXPORTS / "audits"
 REPORTS = EXPORTS / "reports"
+TEMPLATES = Path("nbconvert_html5/templates/semantic-forms")
 
 def do(cmd, *args):
     from doit.cmd_base import CmdAction
@@ -49,6 +50,7 @@ def task_copy(notebooks, configurations, target):
     CONFIGS = target / "configs"
     notebooks = list(map(Path, notebooks))
     configurations = list(map(Path, configurations))
+    styles = list(TEMPLATES.glob("*.css"))
     targets = [NB / x.name for x in notebooks]
     def readme(target, ext, title):
         body = F"""# {title}\n\n"""
@@ -61,6 +63,13 @@ def task_copy(notebooks, configurations, target):
         clean=True,
         actions=[(cp, (x, NB /x.name )) for x in notebooks],
         targets=targets,
+        uptodate=list(map(Path.exists, targets))
+    )
+    yield dict(
+        name="styles",
+        clean=True,
+        actions=[(cp, (x, HTML /x.name )) for x in styles],
+        targets=[HTML /x.name  for x in styles],
         uptodate=list(map(Path.exists, targets))
     )
     targets = [CONFIGS / x.name for x in configurations]

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -33,7 +33,7 @@ TEMPLATE = TEMPLATES / "html-templates.html"
 
 # this file contains a template tag that holds the skeleton for notebooks and a cell.
 
-formatter = pygments.formatters.find_formatter_class("html")(style="a11y-light")
+formatter = pygments.formatters.find_formatter_class("html")(style="a11y-light", wrapcode=True)
 lex = pygments.lexers.find_lexer_class("IPython3")()
 
 
@@ -285,7 +285,7 @@ def highlight(code, lang="python", attrs=None):
             code,
             pygments.lexers.get_lexer_by_name(lang or "python"),
             pygments.formatters.get_formatter_by_name(
-                "html", debug_token_types=True, title=f"{lang} code"
+                "html", debug_token_types=True, title=f"{lang} code", wrapcode=True
             ),
         )
     except:
@@ -323,7 +323,7 @@ class FormExporter(HTMLExporter):
         self.environment.globals.update(vars(builtins))
         import html
 
-        self.environment.globals.update(json=json, markdown=get_markdown)
+        self.environment.globals.update(json=json, markdown=get_markdown, highlight=highlight)
         self.environment.filters.update(escape_html=html.escape)
         self.environment.globals.update(
             formatter=pygments.formatters,

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -330,9 +330,11 @@ class FormExporter(HTMLExporter):
         details = soup.select_one("#toc details")
         if details:
             details.extend(soupify(toc(soup)).children)
-        for x in details.select("ul"):
+        for x in details.select("ul") or []:
             x.name = "ol"
-        details.select_one("ol").attrs["aria-labelledby"] = "nb-toc"
+        ol = details.select_one("ol")
+        if ol:
+            ol.attrs["aria-labelledby"] = "nb-toc"
         return soup.prettify()
 
 

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -279,17 +279,17 @@ def get_markdown(md, **kwargs):
 
 def highlight(code, lang="python", attrs=None):
     import pygments, html
-    print("highlight")
-    # try:
-    return pygments.highlight(
-        code,
-        pygments.lexers.get_lexer_by_name(lang or "python"),
-        pygments.formatters.get_formatter_by_name(
-            "html", debug_token_types=True, title=f"{lang} code"
-        ),
-    )
-    # except:
-    #     return f"""<pre><code>{html.escape(code)}</code></pre>"""
+
+    try:
+        return pygments.highlight(
+            code,
+            pygments.lexers.get_lexer_by_name(lang or "python"),
+            pygments.formatters.get_formatter_by_name(
+                "html", debug_token_types=True, title=f"{lang} code"
+            ),
+        )
+    except:
+        return f"""<pre><code>{html.escape(code)}</code></pre>"""
 
 
 def get_soup(x):
@@ -342,7 +342,7 @@ class FormExporter(HTMLExporter):
         soup = soupify(body)
         describe_main(soup)
         heading_links(soup)
-        details = soup.select_one("""footer[aria-labelledby="nb-toc"] details""")
+        details = soup.select_one("""[aria-labelledby="nb-toc"] details""")
         if details:
             details.extend(soupify(toc(soup)).children)
             for x in details.select("ul"):

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -389,11 +389,13 @@ def count_code_cells(nb):
 
 def describe_main(soup):
     x = soup.select_one("#toc > details > summary")
-    x.attrs["aria-describedby"] = soup.select_one("main").attrs[
-        "aria-describedby"
-    ] = (
-        desc
-    ) = "nb-cells-count-label nb-cells-label nb-code-cells nb-code-cells-label nb-ordered nb-loc nb-loc-label"
+    main = soup.select_one("main")
+    if main:
+        x.attrs["aria-describedby"] = main.attrs[
+            "aria-describedby"
+        ] = (
+            desc
+        ) = "nb-cells-count-label nb-cells-label nb-code-cells nb-code-cells-label nb-ordered nb-loc nb-loc-label"
 
 
 def ordered(nb):

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -327,7 +327,7 @@ class FormExporter(HTMLExporter):
         soup = soupify(body)
         describe_main(soup)
         heading_links(soup)
-        details = soup.select_one("#toc details")
+        details = soup.select_one("""footer[aria-labelledby="nb-toc"] details""")
         if details:
             details.extend(soupify(toc(soup)).children)
             for x in details.select("ul"):

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -330,11 +330,9 @@ class FormExporter(HTMLExporter):
         details = soup.select_one("#toc details")
         if details:
             details.extend(soupify(toc(soup)).children)
-        for x in details.select("ul") or []:
-            x.name = "ol"
-        ol = details.select_one("ol")
-        if ol:
-            ol.attrs["aria-labelledby"] = "nb-toc"
+            for x in details.select("ul"):
+                x.name = "ol"
+            details.select_one("ol").attrs["aria-labelledby"] = "nb-toc"
         return soup.prettify()
 
 

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -389,9 +389,8 @@ def count_code_cells(nb):
 
 def describe_main(soup):
     x = soup.select_one("#toc > details > summary")
-    main = soup.select_one("main")
-    if main:
-        x.attrs["aria-describedby"] = main.attrs[
+    if x:
+        x.attrs["aria-describedby"] = soup.select_one("main").attrs[
             "aria-describedby"
         ] = (
             desc

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -348,7 +348,7 @@ class FormExporter(HTMLExporter):
             for x in details.select("ul"):
                 x.name = "ol"
             details.select_one("ol").attrs["aria-labelledby"] = "nb-toc"
-        return soup.prettify()
+        return soup.encode(formatter="html5")
 
 
 def soupify(body: str) -> BeautifulSoup:

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -320,8 +320,9 @@ class FormExporter(HTMLExporter):
     def post_process_html(self, body):
         soup = soupify(body)
         heading_links(soup)
-        toc_ = soupify(toc(soup))
-        soup.select_one("details#toc").extend(toc_)
+        details = soup.select_one("details#toc")
+        if details:
+            details.extend(soupify(toc(soup)))
         return soup.prettify()
 
 

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -348,12 +348,12 @@ class FormExporter(HTMLExporter):
             for x in details.select("ul"):
                 x.name = "ol"
             details.select_one("ol").attrs["aria-labelledby"] = "nb-toc"
-        return soup.encode(formatter="html5")
+        return soup.prettify(formatter="html5")
 
 
 def soupify(body: str) -> BeautifulSoup:
     """convert a string of html to an beautiful soup object"""
-    return BeautifulSoup(body, features="html.parser")
+    return BeautifulSoup(body, features="html5lib")
 
 
 def mdtoc(html):

--- a/nbconvert_html5/form_exporter.py
+++ b/nbconvert_html5/form_exporter.py
@@ -344,7 +344,7 @@ class FormExporter(HTMLExporter):
         heading_links(soup)
         details = soup.select_one("""[aria-labelledby="nb-toc"] details""")
         if details:
-            details.extend(soupify(toc(soup)).children)
+            details.extend(soupify(toc(soup)).body.children)
             for x in details.select("ul"):
                 x.name = "ol"
             details.select_one("ol").attrs["aria-labelledby"] = "nb-toc"

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -157,7 +157,7 @@ In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span 
     <label aria-hidden="true" for="cell-{{i}}-source">{{label}}</label>
     <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
         aria-labelledby="cell-{{i}}-input">{{source}}</textarea>
-    {{markdown("```python\n"+ source + "\n```")}}
+    {{highlight(source)}}
 </fieldset>
 {% endmacro %}
 

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -1,147 +1,86 @@
-{%- extends 'display_priority.j2' -%}
+{%- extends 'semantic-forms/displays.j2.html' -%}
 {% from 'celltags.j2' import celltags %}
 
-{% block execute_result -%}
-{%- set extra_class="output_execute_result" -%}
-{% block data_priority scoped %}
-{{ super() }}
-{% endblock data_priority %}
-{%- set extra_class="" -%}
-{%- endblock execute_result %}
+{%- block header -%}
+<!DOCTYPE html>
+<html lang="en">
 
-{% block stream_stdout -%}
-<pre class="stdout">
-<code>{{- output.text -}}</code>
-</pre>
-{%- endblock stream_stdout %}
+<head>
+    {%- block head -%}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{title}}</title>
+    <meta name="color-scheme" content="dark light">
 
-{% block stream_stderr -%}
-<pre class="stdout">
-<code>{{- output.text -}}</code>
-</pre>
-{%- endblock stream_stderr %}
+    <link rel="stylesheet" href="style.css">
+    {%- endblock head -%}
+    {%- block html_head_js_mathjax -%}{%- endblock html_head_js_mathjax -%}
+</head>
+{%- endblock header -%}
 
-{% block data_svg scoped -%}
-    {%- if output.svg_filename %}
-    <img src="{{ output.svg_filename | posix_path | escape_html }}">
-    {%- else %}
-    {{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
-    {%- endif %}
-{%- endblock data_svg %}
+{% block any_cell %}{{cell_section(cell, loop)}}{% endblock any_cell %}
 
-{% block data_html scoped -%}
-{%- if resources.should_sanitize_html %}
-{%- set html_value=output.data['text/html'] | clean_html -%}
-{%- else %}
-{%- set html_value=output.data['text/html'] -%}
-{%- endif %}
-{%- if output.get('metadata', {}).get('text/html', {}).get('isolated') -%}
-<iframe class="isolated-iframe" style="height:520px; width:100%; margin:0; padding: 0" frameborder="0" scrolling="auto"
-    src="data:text/html;base64,{{ html_value | text_base64 }}">
-</iframe>
-{%- else -%}
-{{ html_value }}
-{%- endif -%}
-{%- endblock data_html %}
+{% block body_header %}
 
-{% block data_markdown scoped -%}
-{%- if resources.should_sanitize_html %}
-{%- set html_value=output.data['text/markdown'] | markdown2html | clean_html -%}
-{%- else %}
-{%- set html_value=output.data['text/markdown'] | markdown2html -%}
-{%- endif %}
-{{ html_value }}
-{%- endblock data_markdown %}
+<body>
+    <header class="site" aria-labelledby="nb-skip-links-label" class="visually-hidden">
+        {% block skip_links %}
+        <label aria-hidden="true" id="nb-skip-links-label">skip links</label>
+        <a accesskey="0" href="#cells">Skip to content</a>
+        {% endblock skip_links %}
+    </header>
+    {% include "semantic-forms/settings.html.j2" %}
+    <main id=notebook aria-labelledby="nb-title">
+        {% block main_header scoped %}
+        <header id="toc" aria-labelledby="nb-toc" role="region">
+            <details>
+                <summary><span id="nb-title">{{title}}</span> <span id="nb-toc">table of contents</span>
+                </summary>
+            </details>
+        </header>
+        {% endblock main_header %}
+        {% endblock body_header %}
 
-{% block data_png scoped %}
-{# <figure class="png"> #}
-    {%- if 'image/png' in output.metadata.get('filenames', {}) %}
-    <img src="{{ output.metadata.filenames['image/png'] | posix_path | escape_html }}" {%- else %} <img
-        src="data:image/png;base64,{{ output.data['image/png'] | escape_html }}" {%- endif %} {%- set width=output |
-        get_metadata('width', 'image/png' ) -%} {%- if width is not none %} width={{ width | escape_html }} {%- endif %}
-        {%- set height=output | get_metadata('height', 'image/png' ) -%} {%- if height is not none %} height={{ height |
-        escape_html }} {%- endif %} {%- if output | get_metadata('unconfined', 'image/png' ) %} class="unconfined" {%-
-        endif %} {%- set alttext=(output | get_metadata('alt', 'image/png' )) or (cell | get_metadata('alt')) -%} {%- if
-        alttext is not none %} alt="{{ alttext | escape_html }}" {%- endif %}>
-    {#
-</figure> #}
-{%- endblock data_png %}
+        {% block body_footer %}
+        <form name="notebook" aria-labelledby="nb-controls-label">
+            <fieldset>
+                <legend id="nb-controls-label">Notebook Controls</legend>
+                <ul role="toolbar">
+                    <li><button type="submit">Run All</button></li>
+                </ul>
+            </fieldset>
+        </form>
+        <dialog>
+            <fieldset name="metadata" form="notebook">
+            </fieldset>
+            <form method="dialog">
+                <button>Close</button>
+            </form>
+        </dialog>
+        <footer role="log">
+            <ol id="log" aria-relevant="additions"></ol>
+        </footer>
+    </main>
+</body>
+<script>
+    function openDialog(x) {
+        document.getElementById(x.dataset.controls).showModal();
+    };
 
-{% block data_jpg scoped %}
-{# <figure class="jpeg jpg"> #}
-    {%- if 'image/jpeg' in output.metadata.get('filenames', {}) %}
-    <img src="{{ output.metadata.filenames['image/jpeg'] | posix_path | escape_html }}" {%- else %} <img
-        src="data:image/jpeg;base64,{{ output.data['image/jpeg'] | escape_html }}" {%- endif %} {%- set width=output |
-        get_metadata('width', 'image/jpeg' ) -%} {%- if width is not none %} width={{ width | escape_html }} {%- endif
-        %} {%- set height=output | get_metadata('height', 'image/jpeg' ) -%} {%- if height is not none %} height={{
-        height | escape_html }} {%- endif %} {%- if output | get_metadata('unconfined', 'image/jpeg' ) %}
-        class="unconfined" {%- endif %} {%- set alttext=(output | get_metadata('alt', 'image/jpeg' )) or (cell |
-        get_metadata('alt')) -%} {%- if alttext is not none %} alt="{{ alttext | escape_html }}" {%- endif %}>
-    {#
-</figure> #}
-{%- endblock data_jpg %}
+    function toggleColorScheme(x) {
+        let scheme = document.querySelector(`head > meta[name="color-scheme"]`);
+        scheme.content = x.value;
+        log(`${scheme.content} mode activated`);
+    }
 
-{% block data_latex scoped %}
-{# <figure class="latex"> #}
-    {{ output.data['text/latex'] | e }}
-    {# </figure> #}
-{%- endblock data_latex %}
-
-{% block error -%}
-<pre class="exception">
-{{- super() -}}
-</pre>
-{%- endblock error %}
-
-{%- block traceback_line %}
-{{ line | ansi2html }}
-{%- endblock traceback_line %}
-
-{%- block data_text scoped %}
-<pre class="plain">
-{{- output.data['text/plain'] | ansi2html -}}
-</pre>
-{%- endblock -%}
-
-{%- block data_javascript scoped %}
-{% set div_id = uuid4() %}
-<div id="{{ div_id }}" class="output_subarea output_javascript {{ extra_class }}">
-    {%- if not resources.should_sanitize_html %}
-    <script type="text/javascript">
-        var element = $('#{{ div_id }}');
-        { { output.data['application/javascript'] } }
-    </script>
-    {%- endif %}
-</div>
-{%- endblock -%}
-
-{%- block data_widget_view scoped %}
-{%- if not resources.should_sanitize_html %}
-{% set div_id = uuid4() %}
-{% set datatype_list = output.data | filter_data_type %}
-{% set datatype = datatype_list[0]%}
-<div id="{{ div_id }}" class="output_subarea output_widget_view {{ extra_class }}">
-    <script type="text/javascript">
-        var element = $('#{{ div_id }}');
-    </script>
-    <script type="{{ datatype }}">
-{{ output.data[datatype] | json_dumps | escape_html }}
+    function log(x) {
+        document.getElementById("log").innerHTML += `<li>${x}</li>`;
+    }
 </script>
-</div>
-{%- endif %}
-{%- endblock data_widget_view -%}
 
-{%- block footer %}
-{%- if not resources.should_sanitize_html %}
-{% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
-{% if mimetype in nb.metadata.get("widgets",{})%}
-<script type="{{ mimetype }}">
-{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html }}
-</script>
-{% endif %}
-{%- endif %}
-{{ super() }}
-{%- endblock footer-%}
+</html>
+{% endblock body_footer %}
+
 
 {% macro cell_section(cell, loop) %}
 <section class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
@@ -158,7 +97,8 @@
 {% endmacro%}
 
 {% macro cell_anchor(i) %}
-<a href="#{{i}}" id="{{i}}" aria-describedby="cell-{{i}}-input"><span class="visually-hidden">Cell</span>#{{i}}</a>
+<a href="#{{i}}" id="{{i}}" aria-describedby="cell-{{i}}-input"><span
+        class="visually-hidden">Cell</span>#{{i}}</a>
 {% endmacro %}
 
 {% macro cell_cell_type(i, cell_type) %}
@@ -171,7 +111,7 @@
 {% endmacro %}
 
 {% macro cell_execution_count(i, execution_count) %}
-<output form="cell-{{i}}" name="execution_count">{{execution_count}}</output>
+<output form="cell-{{i}}" name="execution_count" id="cell-{{i}}-execution_count">#{{execution_count}}</output>
 {% endmacro %}
 
 {% macro cell_form(i) %}
@@ -181,11 +121,13 @@
 {% endmacro %}
 
 {% macro cell_source(i, source, execution_count) %}
-<fieldset name="input" disabled>
-    <legend id="cell-{{i}}-input">In<span aria-hidden="true">[</span>{{execution_count}}<span
-            aria-hidden="true">]</span></legend>
-    <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source"
-        rows="{{source.splitlines().__len__()}}" aria-labelledby="cell-{{i}}-input">{{source}}</textarea>
+<fieldset name="input" disabled role="presentation">
+    <legend aria-hidden="true">
+        <span id="cell-{{i}}-input">In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span
+            aria-hidden="true">]</span>
+    </legend>
+    <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
+        aria-labelledby="cell-{{i}}-input cell-{{i}}-execution_count">{{source}}</textarea>
 </fieldset>
 {% endmacro %}
 
@@ -213,10 +155,4 @@
     {{ markdown(source) | strip_files_prefix }}
     {% endif %}
 </fieldset>
-{%- endmacro -%}
-
-{%- macro cell_display_priority(i, outputs, cell) -%}
-{%- for i, output in enumerate(outputs) -%}
-{%- block output scoped -%}{{super()}}{%- endblock -%}
-{%- endfor -%}
 {%- endmacro -%}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -25,6 +25,8 @@ the notebook experiennce from browse to edit/focus mode.
 
     {# non-html resources, css and javascript, are served as external resources to optimize load times. #}
     <link rel="stylesheet" href="style.css">
+    <link id="nb-dark-theme" media="screen" rel="stylesheet" href="dark-code.css">
+    <link id="nb-light-theme" media="none" rel="stylesheet" href="light-code.css">
     {%- endblock head -%}
     {%- block html_head_js_mathjax -%}{%- endblock html_head_js_mathjax -%}
 </head>
@@ -45,7 +47,7 @@ the notebook experiennce from browse to edit/focus mode.
                 <a href="#nb-toc" accesskey="0">table of contents</a>
             </li>
             <li>
-            <button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
+                <button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
             </li>
         </ul>
     </header>
@@ -101,8 +103,14 @@ the notebook experiennce from browse to edit/focus mode.
     };
 
     function toggleColorScheme(x) {
-        let scheme = document.querySelector(`head > meta[name="color-scheme"]`);
+        const scheme = document.querySelector(`head > meta[name="color-scheme"]`);
         scheme.content = x.value;
+
+        // handle code theme, will have to do this will meramid
+        document.getElementById(`nb-${x.value}-theme`).setAttribute("media", "all")
+        const opposite = x.value == "dark" ? "light" : "dark"
+        document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none")
+
         setCookie("colorTheme", x.value, 30);
     }
 

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -27,8 +27,10 @@ the notebook experiennce from browse to edit/focus mode.
 
     {# non-html resources, css and javascript, are served as external resources to optimize load times. #}
     <link rel="stylesheet" href="style.css">
-    <link id="nb-light-theme" media="screen" rel="stylesheet" href="light-code.css">
-    <link id="nb-dark-theme" media="none" rel="stylesheet" href="dark-code.css">
+    <link id="nb-light-theme" rel="stylesheet" href="light-code.css">
+    <link id="nb-dark-theme" disabled rel="stylesheet" href="dark-code.css">
+    <style id="nb-font-size-style"></style>
+    <style id="nb-font-family-style"></style>
     {%- endblock head -%}
     {%- block html_head_js_mathjax -%}{%- endblock html_head_js_mathjax -%}
 </head>
@@ -66,11 +68,11 @@ the notebook experiennce from browse to edit/focus mode.
                 {# the table of contents is populated in python. #}
             </details>
         </section>
-        <main>
+        <section role="main">
             {% endblock body_header %}
 
             {% block body_footer %}
-        </main>
+        </section>
         <dialog id="nb-metadata">
             <fieldset name="metadata" form="notebook">
             </fieldset>
@@ -95,9 +97,8 @@ the notebook experiennce from browse to edit/focus mode.
     it is difficult to access for keyboard users. #}
     {% include "semantic-forms/settings.html.j2" %}
     <footer>
-        <fieldset name="log" id="log" role="log" aria-live="polite">
-            <legend>activity</legend>
-        </fieldset>
+        <section id="log" role="log" aria-live="polite" aria-label="activity">
+        </section>
     </footer>
     <script>
         function openDialog(x) {
@@ -112,8 +113,6 @@ the notebook experiennce from browse to edit/focus mode.
             body.append(out);
         };
     </script>
-    <style id="nb-font-size-style"></style>
-    <style id="nb-font-family-style"></style>
 </body>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -7,6 +7,7 @@ the notebook experiennce from browse to edit/focus mode.
 
 {%- extends 'semantic-forms/displays.j2.html' -%}
 {% from 'celltags.j2' import celltags %}
+{% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
 {%- block header -%}
 <!DOCTYPE html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -157,7 +157,7 @@ the notebook experiennce from browse to edit/focus mode.
 
     document.querySelectorAll("[role=toolbar]").forEach(toolbar)
     function toggleOrientation(x) {
-        document.querySelector("header#skip-links ul").setAttribute("aria-orientation", x.matches ? "vertical" : "horizontal")
+        document.querySelector("header#skip-link ul").setAttribute("aria-orientation", x.matches ? "vertical" : "horizontal")
     }
 
     var x = window.matchMedia("(max-width: 576px)")

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -103,13 +103,6 @@ the notebook experiennce from browse to edit/focus mode.
         document.getElementById(x.getAttribute("aria-controls")).showModal();
     };
 
-    function toggleColorScheme(x) {
-        document.querySelector(`head > meta[name="color-scheme"]`).content = x.value;
-        {# handle code theme, will have to do this will meramid #}
-        document.getElementById(`nb-${x.value}-theme`).setAttribute("media", "all");
-        const opposite = x.value == "dark" ? "light" : "dark";
-        document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none");
-    }
 </script>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -21,12 +21,12 @@ the notebook experiennce from browse to edit/focus mode.
     {# color scheme signals that notebooks can viewed in light and dark mode.
     the html representation is used instead of the css representation so it is immediately avaiable.
     https://css-tricks.com/almanac/properties/c/color-scheme/ #}
-    <meta name="color-scheme" content="dark light">
+    <meta name="color-scheme" content="light">
 
     {# non-html resources, css and javascript, are served as external resources to optimize load times. #}
     <link rel="stylesheet" href="style.css">
-    <link id="nb-dark-theme" media="screen" rel="stylesheet" href="dark-code.css">
-    <link id="nb-light-theme" media="none" rel="stylesheet" href="light-code.css">
+    <link id="nb-light-theme" media="screen" rel="stylesheet" href="light-code.css">
+    <link id="nb-dark-theme" media="none" rel="stylesheet" href="dark-code.css">
     {%- endblock head -%}
     {%- block html_head_js_mathjax -%}{%- endblock html_head_js_mathjax -%}
 </head>
@@ -41,13 +41,13 @@ the notebook experiennce from browse to edit/focus mode.
         <label aria-hidden="true" id="nb-skip-links-label">skip links</label>
         <ul role="toolbar">
             <li>
-                <a href="#cells" tabindex="0" accesskey="1">skip to content</a>
+                <a href="#cells" tabindex="0" accesskey="1">skip to content</a><kbd>›</kbd>
             </li>
             <li>
-                <a href="#nb-toc" accesskey="0">table of contents</a>
+                <kbd>‹</kbd><a href="#nb-toc" accesskey="0">table of contents</a><kbd>›</kbd>
             </li>
             <li>
-                <button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
+                <kbd>‹</kbd><button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
             </li>
         </ul>
     </header>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -37,132 +37,80 @@ the notebook experiennce from browse to edit/focus mode.
 {% block body_header %}
 
 <body>
-    <header id="skip-link" role="group" aria-labelledby="nb-skip-links-label">
-        <label aria-hidden="true" id="nb-skip-links-label">skip links</label>
-        <ul role="toolbar" aria-orientation="horizontal">
-            <li>
-                <a href="#cells" tabindex="0" accesskey="1">skip to content</a>
-            </li>
-            <li>
-                <a href="#nb-toc" accesskey="0">table of contents</a>
-            </li>
-            <li>
-                <button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
-            </li>
-        </ul>
+    <section id="skip-link">
+        <a href="#cells" tabindex="0" accesskey="1">skip to content</a>
+    </section>
+    <header aria-label="site header">
+        {# the skip link is the first tab stop in the site to skip repetitive information
+        and directly access the content. #}
+        {# site authors with include their site specific headers in this region. #}
+        {# a subsequent tab stop will indicate to keyboard and AT users that there are
+        accessibility settings that can be toggled. #}
+        <button onclick="openDialog(this)" aria-controls="nb-settings">Settings</button>
     </header>
-    <header></header>
-    <main id=notebook aria-labelledby="nb-title">
+    {# this is the main section, but we want landmark navigation to go to the first cell in
+    the notebook. the extending template will define the location of the main content. #}
+    <section id=notebook role="group">
+        <section aria-labelledby="nb-toc">
+            {# a notebook will provide visual structural navigation for a document.
+            this is a feature of screen readers that is not common to sighted users.
+            the implementation here is very naive. users will need to know to collapse the heading
+            to skip the link tree. the best implementation is a tree that will consume a single tab stop
+            and allow arrow key navigation. #}
+            <details open>
+                <summary><span id="nb-toc">table of contents</span></summary>
+                {# the table of contents is populated in python. #}
+            </details>
+        </section>
         {% block main_header scoped %}
         {% endblock main_header %}
         {% endblock body_header %}
 
         {% block body_footer %}
+        {# a notebook begins as a static document that can progressively
+        add features like run time computation. #}
         <form name="notebook" aria-labelledby="nb-controls-label">
-            <fieldset>
+            <fieldset disabled>
                 <legend id="nb-controls-label">Notebook Controls</legend>
-                <ul role="toolbar">
-                    <li><button type="submit">Run All</button></li>
-                </ul>
+                <button type="submit">Run</button>
             </fieldset>
         </form>
-        <footer aria-labelledby="nb-toc" role="contentinfo">
-            <details open>
-                <summary><span id="nb-toc">table of contents</span></summary>
-                <header hidden>
-                    <i>press</i><a accesskey="." href="#nb-toc"><kbd>.</kbd></a><i id="nb-toc-description">skip to table
-                        of contents</i>
-                </header>
-            </details>
-        </footer>
-        <footer>
-            <dialog>
-                <fieldset name="metadata" form="notebook">
-                </fieldset>
-                <form method="dialog">
-                    <button>Close</button>
-                </form>
-            </dialog>
-        </footer>
-        <footer>
-            <ol id="log" aria-relevant="additions"></ol>
-        </footer>
-    </main>
-    <footer></footer>
+        <dialog id="nb-metadata">
+            <fieldset name="metadata" form="notebook">
+            </fieldset>
+            <form method="dialog">
+                <button>Close</button>
+            </form>
+        </dialog>
+        {# skip to top is needed for long notebooks.
+        it is difficult to access for keyboard users. #}
+        <a href="#notebook">skip to top</a>
+    </section>
     {% include "semantic-forms/settings.html.j2" %}
+    <footer>
+        <fieldset>
+            <legend>application controls</legend>
+            <label for="nb-activate">edit mode</label>
+            <input id="nb-activate" type="checkbox">
+            <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
+        </fieldset>
+
+        <ol id="log" aria-relevant="additions"></ol>
+    </footer>
 </body>
 <script>
-    function setCookie(cname, cvalue, exdays) {
-        const d = new Date();
-        d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
-        let expires = "expires=" + d.toUTCString();
-        document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-    }
     function openDialog(x) {
-        document.getElementById(x.dataset.controls).showModal();
+        document.getElementById(x.getAttribute("aria-controls")).showModal();
     };
 
     function toggleColorScheme(x) {
         const scheme = document.querySelector(`head > meta[name="color-scheme"]`);
         scheme.content = x.value;
-
         // handle code theme, will have to do this will meramid
-        document.getElementById(`nb-${x.value}-theme`).setAttribute("media", "all")
-        const opposite = x.value == "dark" ? "light" : "dark"
-        document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none")
-
-        setCookie("colorTheme", x.value, 30);
+        document.getElementById(`nb-${x.value}-theme`).setAttribute("media", "all");
+        const opposite = x.value == "dark" ? "light" : "dark";
+        document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none");
     }
-
-    function log(x) {
-        document.getElementById("log").innerHTML += `<li>${x}</li>`;
-    }
-
-    function focusHandler(x) { }
-    function keyHandler(x) {
-        let parent = x.target.parentNode;
-        let toolbar = parent.parentNode;
-        let next = null;
-
-        if (x.keyCode == 37) {
-            next = parent.previousElementSibling;
-        } else if (x.keyCode == 39) {
-            next = parent.nextElementSibling;
-        }
-
-        if (next) {
-            toolbar.querySelectorAll("li").forEach(
-                (z) => {
-                    let tabindex = z === next ? 0 : -1;
-                    let a = z.querySelector(`a, button`);
-                    a.setAttribute("tabindex", tabindex);
-                    tabindex == 0 ? a.focus() : null;
-                }
-            )
-        }
-
-    }
-    function toolbar(x) {
-        let tools = x.querySelectorAll("a, button");
-
-        tools.forEach(
-            (y, i) => {
-                if (!y.hasAttribute("tabindex")) {
-                    y.setAttribute("tabindex", i == 0 ? 0 : -1);
-                }
-                y.addEventListener("keydown", keyHandler);
-                y.addEventListener("onfocus", focusHandler);
-            });
-    }
-
-    document.querySelectorAll("[role=toolbar]").forEach(toolbar)
-    function toggleOrientation(x) {
-        document.querySelector("header#skip-link ul").setAttribute("aria-orientation", x.matches ? "vertical" : "horizontal")
-    }
-
-    var x = window.matchMedia("(max-width: 576px)")
-    toggleOrientation(x) // Call listener function at run time
-    x.addListener(toggleOrientation) // Attach listener function on state changes 
 </script>
 
 </html>
@@ -214,7 +162,7 @@ In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span 
     <legend hidden id="cell-{{i}}-input">
         In {{execution_count}}
     </legend>
-    <label aria-hidden="true">{{label}}</label>
+    <label aria-hidden="true" for="cell-{{i}}-source">{{label}}</label>
     <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
         aria-labelledby="cell-{{i}}-input">{{source}}</textarea>
     {{markdown("```python\n"+ source + "\n```")}}
@@ -240,7 +188,9 @@ In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span 
 <span hidden id="cell-{{i}}-outputs-len">{{outputs.__len__()}} outputs</span>
 <fieldset name="outputs" id="cell-{{i}}-outputs" aria-describedby="cell-{{i}}-outputs-len">
     <legend hidden>Out {{execution_count}}</legend>
-    <label aria-hidden="true" for="cell-{{i}}-outputs">{{label}}</label>
+    {% if outputs %}
+    <span aria-hidden="true">{{label}}</span>
+    {% endif %}
     {% if CODE and outputs %}
     {{cell_display_priority(i, outputs, cell)}}
     {% elif cell_type=="markdown" %}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -50,7 +50,7 @@ the notebook experiennce from browse to edit/focus mode.
         {# site authors with include their site specific headers in this region. #}
         {# a subsequent tab stop will indicate to keyboard and AT users that there are
         accessibility settings that can be toggled. #}
-        <button onclick="openDialog(this)" aria-controls="nb-settings" accesskey=",">Settings</button>
+        <button onclick="openDialog()" aria-controls="nb-settings" accesskey=",">Settings</button>
     </header>
     {# this is the main section, but we want landmark navigation to go to the first cell in
     the notebook. the extending template will define the location of the main content. #}
@@ -89,7 +89,7 @@ the notebook experiennce from browse to edit/focus mode.
             <legend id="nb-controls-label">Notebook Controls</legend>
             <button type="submit">Run</button>
         </fieldset>
-        <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
+        <button onclick="openDialog()" aria-controls="nb-metadata">Metadata</button>
     </form>
     {# skip to top is needed for long notebooks.
     it is difficult to access for keyboard users. #}
@@ -101,24 +101,6 @@ the notebook experiennce from browse to edit/focus mode.
         </fieldset>
         <a href="#notebook" accesskey="0">skip to top</a>
     </footer>
-    <script>
-        function openDialog(x) {
-            event.preventDefault();
-            document.getElementById(event.target.getAttribute("aria-controls")).showModal();
-        };
-
-        function activityLog(msg, silent = false) {
-            document.querySelectorAll(".activityLog").forEach(
-                (body) => {
-                    let out = document.createElement("output");
-                    out.textContent = msg;
-                    silent ? out.setAttribute("aria-hidden", true) : null;
-                    body.append(out);
-                }
-            )
-
-        };
-    </script>
 </body>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -39,15 +39,15 @@ the notebook experiennce from browse to edit/focus mode.
 <body>
     <header id="skip-link" role="group" aria-labelledby="nb-skip-links-label">
         <label aria-hidden="true" id="nb-skip-links-label">skip links</label>
-        <ul role="toolbar">
+        <ul role="toolbar" aria-orientation="horizontal">
             <li>
-                <a href="#cells" tabindex="0" accesskey="1">skip to content</a><kbd>›</kbd>
+                <a href="#cells" tabindex="0" accesskey="1">skip to content</a>
             </li>
             <li>
-                <kbd>‹</kbd><a href="#nb-toc" accesskey="0">table of contents</a><kbd>›</kbd>
+                <a href="#nb-toc" accesskey="0">table of contents</a>
             </li>
             <li>
-                <kbd>‹</kbd><button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
+                <button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
             </li>
         </ul>
     </header>
@@ -156,6 +156,13 @@ the notebook experiennce from browse to edit/focus mode.
     }
 
     document.querySelectorAll("[role=toolbar]").forEach(toolbar)
+    function toggleOrientation(x) {
+        document.querySelector("header#skip-links ul").setAttribute("aria-orientation", x.matches ? "vertical" : "horizontal")
+    }
+
+    var x = window.matchMedia("(max-width: 576px)")
+    toggleOrientation(x) // Call listener function at run time
+    x.addListener(toggleOrientation) // Attach listener function on state changes 
 </script>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -54,8 +54,8 @@ the notebook experiennce from browse to edit/focus mode.
     </header>
     {# this is the main section, but we want landmark navigation to go to the first cell in
     the notebook. the extending template will define the location of the main content. #}
-    <fieldset form="notebook">
-        <legend>notebook</legend>
+    <fieldset form="notebook" role="presentation">
+        <legend id="nb-notebook-label" hidden>notebook</legend>
         <section aria-labelledby="nb-toc">
             {# a notebook will provide visual structural navigation for a document.
             this is a feature of screen readers that is not common to sighted users.
@@ -68,7 +68,7 @@ the notebook experiennce from browse to edit/focus mode.
                 {# the table of contents is populated in python. #}
             </details>
         </section>
-        <section role="main">
+        <section role="main" aria-labelledby="nb-notebook-label">
             {% endblock body_header %}
 
             {% block body_footer %}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -96,7 +96,7 @@ the notebook experiennce from browse to edit/focus mode.
     {% include "semantic-forms/settings.html.j2" %}
     <footer>
         <fieldset form="notebook" name="log">
-            <ul class="activityLog" role="log" aria-live="polite">
+            <ul class="activityLog" aria-live="polite">
             </ul>
         </fieldset>
         <a href="#notebook" accesskey="0">skip to top</a>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -79,8 +79,8 @@ the notebook experiennce from browse to edit/focus mode.
             <form method="dialog">
                 <button>Close</button>
             </form>
-        </dialog>
-    </fieldset>
+        </fieldset>
+    </dialog>
     {# a notebook begins as a static document that can progressively
     add features like run time computation. #}
     <form name="notebook" id="notebook" aria-labelledby="nb-controls-label">
@@ -95,21 +95,28 @@ the notebook experiennce from browse to edit/focus mode.
     it is difficult to access for keyboard users. #}
     {% include "semantic-forms/settings.html.j2" %}
     <footer>
-        <section id="log" role="log" aria-live="polite" aria-label="activity">
-        </section>
+        <fieldset form="notebook" name="log">
+            <section class="activityLog" role="log" aria-live="polite">
+            </section>
+        </fieldset>
         <a href="#notebook" accesskey="0">skip to top</a>
     </footer>
     <script>
         function openDialog(x) {
-            document.getElementById(x.getAttribute("aria-controls")).showModal();
+            event.preventDefault();
+            document.getElementById(event.target.getAttribute("aria-controls")).showModal();
         };
 
-        function activityLog(msg, at = true) {
-            const body = document.querySelector("#log");
-            let out = document.createElement("output");
-            out.textContent = msg;
-            at ? null : out.setAttribute("aria-hidden", true);
-            body.append(out);
+        function activityLog(msg, silent = false) {
+            document.querySelectorAll(".activityLog").forEach(
+                (body) => {
+                    let out = document.createElement("output");
+                    out.textContent = msg;
+                    silent ? out.setAttribute("aria-hidden", true) : null;
+                    body.append(out);
+                }
+            )
+
         };
     </script>
 </body>
@@ -172,12 +179,12 @@ In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span 
 {% macro cell_metadata(i, metadata) %}
 <button name="metadata" form="cell-{{i}}">Metadata</button>
 <dialog id="cell-{{i}}-metadata">
+    <form>
+        <button formmethod="dialog">Close</button>
+    </form>
     <pre><code>
     {{metadata}}
     </code></pre>
-    <form method="dialog">
-        <button>Close</button>
-    </form>
 </dialog>
 {% endmacro %}
 

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -35,12 +35,19 @@ the notebook experiennce from browse to edit/focus mode.
 {% block body_header %}
 
 <body>
-    <header class="site" aria-labelledby="nb-skip-links-label" class="visually-hidden" role="presentation">
-        {% block skip_links %}
+    <header id="skip-link" role="group" aria-labelledby="nb-skip-links-label">
         <label aria-hidden="true" id="nb-skip-links-label">skip links</label>
-        <a accesskey="," href="#cells">Skip to content</a>
-        {% endblock skip_links %}
-        {% include "semantic-forms/settings.html.j2" %}
+        <ul role="toolbar">
+            <li>
+                <a href="#cells" tabindex="0">skip to content</a>
+            </li>
+            <li>
+                <a href="#nb-toc">table of contents</a>
+            </li>
+            <li>
+                <button>settings & accessibility</button>
+            </li>
+        </ul>
     </header>
     <header></header>
     <main id=notebook aria-labelledby="nb-title">
@@ -101,6 +108,45 @@ the notebook experiennce from browse to edit/focus mode.
     function log(x) {
         document.getElementById("log").innerHTML += `<li>${x}</li>`;
     }
+
+    function focusHandler(x) { }
+    function keyHandler(x) {
+        let parent = x.target.parentNode;
+        let toolbar = parent.parentNode;
+        let next = null;
+
+        if (x.keyCode == 37) {
+            next = parent.previousElementSibling;
+        } else if (x.keyCode == 39) {
+            next = parent.nextElementSibling;
+        }
+
+        if (next) {
+            toolbar.querySelectorAll("li").forEach(
+                (z) => {
+                    let tabindex = z === next ? 0 : -1;
+                    let a = z.querySelector(`a, button`);
+                    a.setAttribute("tabindex", tabindex);
+                    tabindex == 0 ? a.focus() : null;
+                }
+            )
+        }
+
+    }
+    function toolbar(x) {
+        let tools = x.querySelectorAll("a, button");
+
+        tools.forEach(
+            (y, i) => {
+                if (!y.hasAttribute("tabindex")) {
+                    y.setAttribute("tabindex", i == 0 ? 0 : -1);
+                }
+                y.addEventListener("keydown", keyHandler);
+                y.addEventListener("onfocus", focusHandler);
+            });
+    }
+
+    document.querySelectorAll("[role=toolbar]").forEach(toolbar)
 </script>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -1,3 +1,10 @@
+{# # a base template for accessible notebook representations.
+
+the base template defines notebook independent components.
+an accessible base template provides a substrate to progressively enchance
+the notebook experiennce from browse to edit/focus mode.
+#}
+
 {%- extends 'semantic-forms/displays.j2.html' -%}
 {% from 'celltags.j2' import celltags %}
 
@@ -9,9 +16,14 @@
     {%- block head -%}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {# use technique [h25] to provide a title to satisfy [2.4.2A]. #}
     <title>{{title}}</title>
+    {# color scheme signals that notebooks can viewed in light and dark mode.
+    the html representation is used instead of the css representation so it is immediately avaiable.
+    https://css-tricks.com/almanac/properties/c/color-scheme/ #}
     <meta name="color-scheme" content="dark light">
 
+    {# non-html resources, css and javascript, are served as external resources to optimize load times. #}
     <link rel="stylesheet" href="style.css">
     {%- endblock head -%}
     {%- block html_head_js_mathjax -%}{%- endblock html_head_js_mathjax -%}
@@ -23,21 +35,16 @@
 {% block body_header %}
 
 <body>
-    <header class="site" aria-labelledby="nb-skip-links-label" class="visually-hidden">
+    <header class="site" aria-labelledby="nb-skip-links-label" class="visually-hidden" role="presentation">
         {% block skip_links %}
         <label aria-hidden="true" id="nb-skip-links-label">skip links</label>
-        <a accesskey="0" href="#cells">Skip to content</a>
+        <a accesskey="," href="#cells">Skip to content</a>
         {% endblock skip_links %}
+        {% include "semantic-forms/settings.html.j2" %}
     </header>
-    {% include "semantic-forms/settings.html.j2" %}
+    <header></header>
     <main id=notebook aria-labelledby="nb-title">
         {% block main_header scoped %}
-        <header id="toc" aria-labelledby="nb-toc" role="region">
-            <details>
-                <summary><span id="nb-title">{{title}}</span> <span id="nb-toc">table of contents</span>
-                </summary>
-            </details>
-        </header>
         {% endblock main_header %}
         {% endblock body_header %}
 
@@ -50,19 +57,37 @@
                 </ul>
             </fieldset>
         </form>
-        <dialog>
-            <fieldset name="metadata" form="notebook">
-            </fieldset>
-            <form method="dialog">
-                <button>Close</button>
-            </form>
-        </dialog>
-        <footer role="log">
+        <footer aria-labelledby="nb-toc" role="contentinfo">
+            <details open>
+                <summary><span id="nb-toc">table of contents</span></summary>
+                <header hidden>
+                    <i>press</i><a accesskey="." href="#nb-toc"><kbd>.</kbd></a><i id="nb-toc-description">skip to table
+                        of contents</i>
+                </header>
+            </details>
+        </footer>
+        <footer>
+            <dialog>
+                <fieldset name="metadata" form="notebook">
+                </fieldset>
+                <form method="dialog">
+                    <button>Close</button>
+                </form>
+            </dialog>
+        </footer>
+        <footer>
             <ol id="log" aria-relevant="additions"></ol>
         </footer>
     </main>
+    <footer></footer>
 </body>
 <script>
+    function setCookie(cname, cvalue, exdays) {
+        const d = new Date();
+        d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+        let expires = "expires=" + d.toUTCString();
+        document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+    }
     function openDialog(x) {
         document.getElementById(x.dataset.controls).showModal();
     };
@@ -70,7 +95,7 @@
     function toggleColorScheme(x) {
         let scheme = document.querySelector(`head > meta[name="color-scheme"]`);
         scheme.content = x.value;
-        log(`${scheme.content} mode activated`);
+        setCookie("colorTheme", x.value, 30);
     }
 
     function log(x) {
@@ -97,8 +122,7 @@
 {% endmacro%}
 
 {% macro cell_anchor(i) %}
-<a href="#{{i}}" id="{{i}}" aria-describedby="cell-{{i}}-input"><span
-        class="visually-hidden">Cell</span>#{{i}}</a>
+<a href="#{{i}}" id="{{i}}" aria-labelledby="nb-def-cell {{i}}">{{i}}</a>
 {% endmacro %}
 
 {% macro cell_cell_type(i, cell_type) %}
@@ -121,13 +145,17 @@
 {% endmacro %}
 
 {% macro cell_source(i, source, execution_count) %}
-<fieldset name="input" disabled role="presentation">
-    <legend aria-hidden="true">
-        <span id="cell-{{i}}-input">In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span
-            aria-hidden="true">]</span>
+{% set label -%}
+In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span aria-hidden="true">]</span>
+{%- endset %}
+<fieldset name="input">
+    <legend hidden id="cell-{{i}}-input">
+        In {{execution_count}}
     </legend>
+    <label aria-hidden="true">{{label}}</label>
     <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
-        aria-labelledby="cell-{{i}}-input cell-{{i}}-execution_count">{{source}}</textarea>
+        aria-labelledby="cell-{{i}}-input">{{source}}</textarea>
+    {{markdown("```python\n"+ source + "\n```")}}
 </fieldset>
 {% endmacro %}
 
@@ -145,10 +173,12 @@
 
 {%- macro cell_output(i, cell, source, outputs, cell_type, execution_count) -%}
 {% set CODE = cell_type == "code" %}
+{% set label %}{% if CODE and outputs %}Out<span aria-hidden="true">[</span>{{execution_count}}<span
+    aria-hidden="true">]</span>{% else %}Cell {{i}}{% endif %}{% endset %}
 <span hidden id="cell-{{i}}-outputs-len">{{outputs.__len__()}} outputs</span>
 <fieldset name="outputs" id="cell-{{i}}-outputs" aria-describedby="cell-{{i}}-outputs-len">
-    <legend>Out{% if CODE and outputs %}<span aria-hidden="true">[</span>{{execution_count}}<span
-            aria-hidden="true">]</span>{% endif %}</legend>
+    <legend hidden>Out {{execution_count}}</legend>
+    <label aria-hidden="true" for="cell-{{i}}-outputs">{{label}}</label>
     {% if CODE and outputs %}
     {{cell_display_priority(i, outputs, cell)}}
     {% elif cell_type=="markdown" %}
@@ -156,3 +186,10 @@
     {% endif %}
 </fieldset>
 {%- endmacro -%}
+
+{#
+
+[h25]: https://www.w3.org/WAI/WCAG21/Techniques/html/H25
+[2.4.2A]: https://www.w3.org/WAI/WCAG21/Understanding/page-titled
+
+#}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -9,6 +9,7 @@ the notebook experiennce from browse to edit/focus mode.
 {% from 'celltags.j2' import celltags %}
 {% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
+
 {%- block header -%}
 <!DOCTYPE html>
 <html lang="en">
@@ -105,6 +106,8 @@ the notebook experiennce from browse to edit/focus mode.
             };
 
         </script>
+        <style id="nb-font-size-style"></style>
+        <style id="nb-font-family-style"></style>
 </body>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -70,7 +70,7 @@ the notebook experiennce from browse to edit/focus mode.
         </main>
         {# a notebook begins as a static document that can progressively
         add features like run time computation. #}
-        <form name="notebook" aria-labelledby="nb-controls-label">
+        <form name="notebook" id="notebook" aria-labelledby="nb-controls-label">
             <fieldset disabled>
                 <legend id="nb-controls-label">Notebook Controls</legend>
                 <button type="submit">Run</button>
@@ -97,13 +97,13 @@ the notebook experiennce from browse to edit/focus mode.
         </fieldset>
         <ol id="log" aria-relevant="additions"></ol>
     </footer>
-</body>
-<script>
-    function openDialog(x) {
-        document.getElementById(x.getAttribute("aria-controls")).showModal();
-    };
+    <script>
+        function openDialog(x) {
+            document.getElementById(x.getAttribute("aria-controls")).showModal();
+        };
 
-</script>
+    </script>
+</body>
 
 </html>
 {% endblock body_footer %}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -22,13 +22,11 @@
 {%- endblock stream_stderr %}
 
 {% block data_svg scoped -%}
-{# <figure class="svg"> #}
-{%- if output.svg_filename %}
-<img src="{{ output.svg_filename | posix_path | escape_html }}">
-{%- else %}
-{{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
-{%- endif %}
-{# </figure> #}
+    {%- if output.svg_filename %}
+    <img src="{{ output.svg_filename | posix_path | escape_html }}">
+    {%- else %}
+    {{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
+    {%- endif %}
 {%- endblock data_svg %}
 
 {% block data_html scoped -%}
@@ -38,11 +36,7 @@
 {%- set html_value=output.data['text/html'] -%}
 {%- endif %}
 {%- if output.get('metadata', {}).get('text/html', {}).get('isolated') -%}
-<iframe
-    class="isolated-iframe"
-    style="height:520px; width:100%; margin:0; padding: 0"
-    frameborder="0"
-    scrolling="auto"
+<iframe class="isolated-iframe" style="height:520px; width:100%; margin:0; padding: 0" frameborder="0" scrolling="auto"
     src="data:text/html;base64,{{ html_value | text_base64 }}">
 </iframe>
 {%- else -%}
@@ -61,60 +55,36 @@
 
 {% block data_png scoped %}
 {# <figure class="png"> #}
-{%- if 'image/png' in output.metadata.get('filenames', {}) %}
-<img src="{{ output.metadata.filenames['image/png'] | posix_path | escape_html }}"
-{%- else %}
-<img src="data:image/png;base64,{{ output.data['image/png'] | escape_html }}"
-{%- endif %}
-{%- set width=output | get_metadata('width', 'image/png') -%}
-{%- if width is not none %}
-width={{ width | escape_html }}
-{%- endif %}
-{%- set height=output | get_metadata('height', 'image/png') -%}
-{%- if height is not none %}
-height={{ height | escape_html }}
-{%- endif %}
-{%- if output | get_metadata('unconfined', 'image/png') %}
-class="unconfined"
-{%- endif %}
-{%- set alttext=(output | get_metadata('alt', 'image/png')) or (cell | get_metadata('alt')) -%}
-{%- if alttext is not none %}
-alt="{{ alttext | escape_html }}"
-{%- endif %}
->
-{# </figure> #}
+    {%- if 'image/png' in output.metadata.get('filenames', {}) %}
+    <img src="{{ output.metadata.filenames['image/png'] | posix_path | escape_html }}" {%- else %} <img
+        src="data:image/png;base64,{{ output.data['image/png'] | escape_html }}" {%- endif %} {%- set width=output |
+        get_metadata('width', 'image/png' ) -%} {%- if width is not none %} width={{ width | escape_html }} {%- endif %}
+        {%- set height=output | get_metadata('height', 'image/png' ) -%} {%- if height is not none %} height={{ height |
+        escape_html }} {%- endif %} {%- if output | get_metadata('unconfined', 'image/png' ) %} class="unconfined" {%-
+        endif %} {%- set alttext=(output | get_metadata('alt', 'image/png' )) or (cell | get_metadata('alt')) -%} {%- if
+        alttext is not none %} alt="{{ alttext | escape_html }}" {%- endif %}>
+    {#
+</figure> #}
 {%- endblock data_png %}
 
 {% block data_jpg scoped %}
 {# <figure class="jpeg jpg"> #}
-{%- if 'image/jpeg' in output.metadata.get('filenames', {}) %}
-<img src="{{ output.metadata.filenames['image/jpeg'] | posix_path | escape_html }}"
-{%- else %}
-<img src="data:image/jpeg;base64,{{ output.data['image/jpeg'] | escape_html }}"
-{%- endif %}
-{%- set width=output | get_metadata('width', 'image/jpeg') -%}
-{%- if width is not none %}
-width={{ width | escape_html }}
-{%- endif %}
-{%- set height=output | get_metadata('height', 'image/jpeg') -%}
-{%- if height is not none %}
-height={{ height | escape_html }}
-{%- endif %}
-{%- if output | get_metadata('unconfined', 'image/jpeg') %}
-class="unconfined"
-{%- endif %}
-{%- set alttext=(output | get_metadata('alt', 'image/jpeg')) or (cell | get_metadata('alt')) -%}
-{%- if alttext is not none %}
-alt="{{ alttext | escape_html }}"
-{%- endif %}
->
-{# </figure> #}
+    {%- if 'image/jpeg' in output.metadata.get('filenames', {}) %}
+    <img src="{{ output.metadata.filenames['image/jpeg'] | posix_path | escape_html }}" {%- else %} <img
+        src="data:image/jpeg;base64,{{ output.data['image/jpeg'] | escape_html }}" {%- endif %} {%- set width=output |
+        get_metadata('width', 'image/jpeg' ) -%} {%- if width is not none %} width={{ width | escape_html }} {%- endif
+        %} {%- set height=output | get_metadata('height', 'image/jpeg' ) -%} {%- if height is not none %} height={{
+        height | escape_html }} {%- endif %} {%- if output | get_metadata('unconfined', 'image/jpeg' ) %}
+        class="unconfined" {%- endif %} {%- set alttext=(output | get_metadata('alt', 'image/jpeg' )) or (cell |
+        get_metadata('alt')) -%} {%- if alttext is not none %} alt="{{ alttext | escape_html }}" {%- endif %}>
+    {#
+</figure> #}
 {%- endblock data_jpg %}
 
 {% block data_latex scoped %}
 {# <figure class="latex"> #}
-{{ output.data['text/latex'] | e }}
-{# </figure> #}
+    {{ output.data['text/latex'] | e }}
+    {# </figure> #}
 {%- endblock data_latex %}
 
 {% block error -%}
@@ -136,12 +106,12 @@ alt="{{ alttext | escape_html }}"
 {%- block data_javascript scoped %}
 {% set div_id = uuid4() %}
 <div id="{{ div_id }}" class="output_subarea output_javascript {{ extra_class }}">
-{%- if not resources.should_sanitize_html %}
-<script type="text/javascript">
-var element = $('#{{ div_id }}');
-{{ output.data['application/javascript'] }}
-</script>
-{%- endif %}
+    {%- if not resources.should_sanitize_html %}
+    <script type="text/javascript">
+        var element = $('#{{ div_id }}');
+        { { output.data['application/javascript'] } }
+    </script>
+    {%- endif %}
 </div>
 {%- endblock -%}
 
@@ -151,10 +121,10 @@ var element = $('#{{ div_id }}');
 {% set datatype_list = output.data | filter_data_type %}
 {% set datatype = datatype_list[0]%}
 <div id="{{ div_id }}" class="output_subarea output_widget_view {{ extra_class }}">
-<script type="text/javascript">
-var element = $('#{{ div_id }}');
-</script>
-<script type="{{ datatype }}">
+    <script type="text/javascript">
+        var element = $('#{{ div_id }}');
+    </script>
+    <script type="{{ datatype }}">
 {{ output.data[datatype] | json_dumps | escape_html }}
 </script>
 </div>
@@ -172,3 +142,81 @@ var element = $('#{{ div_id }}');
 {%- endif %}
 {{ super() }}
 {%- endblock footer-%}
+
+{% macro cell_section(cell, loop) %}
+<section class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
+    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
+    data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
+    {{cell_anchor(loop.index)}}
+    {{cell_form(i)}}
+    {{cell_execution_count(loop.index, cell.execution_count)}}
+    {{cell_cell_type(loop.index, cell.cell_type)}}
+    {{cell_source(loop.index, cell.source, cell.execution_count)}}
+    {{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type, cell.execution_count)}}
+    {{cell_metadata(loop.index, cell.metadata)}}
+</section>
+{% endmacro%}
+
+{% macro cell_anchor(i) %}
+<a href="#{{i}}" id="{{i}}" aria-describedby="cell-{{i}}-input"><span class="visually-hidden">Cell</span>#{{i}}</a>
+{% endmacro %}
+
+{% macro cell_cell_type(i, cell_type) %}
+<select form="cell-{{i}}" name="cell_type" disabled>
+    <option value="markdown" {%- if cell_type=="markdown" %} selected{% endif%}>markdown</option>
+    <option value="code" {%- if cell_type=="code" %} selected{% endif%}>code</option>
+    <option value="raw" {%- if cell_type=="raw" %} selected{% endif%}>raw</option>
+</select>
+<span id="cell-{{i}}-cell_type">{{cell_type}}</span>
+{% endmacro %}
+
+{% macro cell_execution_count(i, execution_count) %}
+<output form="cell-{{i}}" name="execution_count">{{execution_count}}</output>
+{% endmacro %}
+
+{% macro cell_form(i) %}
+<form id="cell-{{i}}" name="/cells/{{i}}" aria-labelledby="cell-{{i}}-cell_type">
+    <button type="submit">Run Cell</button>
+</form>
+{% endmacro %}
+
+{% macro cell_source(i, source, execution_count) %}
+<fieldset name="input" disabled>
+    <legend id="cell-{{i}}-input">In<span aria-hidden="true">[</span>{{execution_count}}<span
+            aria-hidden="true">]</span></legend>
+    <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source"
+        rows="{{source.splitlines().__len__()}}" aria-labelledby="cell-{{i}}-input">{{source}}</textarea>
+</fieldset>
+{% endmacro %}
+
+{% macro cell_metadata(i, metadata) %}
+<button name="metadata" form="cell-{{i}}">Metadata</button>
+<dialog id="cell-{{i}}-metadata">
+    <pre><code>
+    {{metadata}}
+    </code></pre>
+    <form method="dialog">
+        <button>Close</button>
+    </form>
+</dialog>
+{% endmacro %}
+
+{%- macro cell_output(i, cell, source, outputs, cell_type, execution_count) -%}
+{% set CODE = cell_type == "code" %}
+<span hidden id="cell-{{i}}-outputs-len">{{outputs.__len__()}} outputs</span>
+<fieldset name="outputs" id="cell-{{i}}-outputs" aria-describedby="cell-{{i}}-outputs-len">
+    <legend>Out{% if CODE and outputs %}<span aria-hidden="true">[</span>{{execution_count}}<span
+            aria-hidden="true">]</span>{% endif %}</legend>
+    {% if CODE and outputs %}
+    {{cell_display_priority(i, outputs, cell)}}
+    {% elif cell_type=="markdown" %}
+    {{ markdown(source) | strip_files_prefix }}
+    {% endif %}
+</fieldset>
+{%- endmacro -%}
+
+{%- macro cell_display_priority(i, outputs, cell) -%}
+{%- for i, output in enumerate(outputs) -%}
+{%- block output scoped -%}{{super()}}{%- endblock -%}
+{%- endfor -%}
+{%- endmacro -%}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -71,14 +71,6 @@ the notebook experiennce from browse to edit/focus mode.
 
             {% block body_footer %}
         </main>
-        {# a notebook begins as a static document that can progressively
-        add features like run time computation. #}
-        <form name="notebook" id="notebook" aria-labelledby="nb-controls-label">
-            <fieldset disabled>
-                <legend id="nb-controls-label">Notebook Controls</legend>
-                <button type="submit">Run</button>
-            </fieldset>
-        </form>
         <dialog id="nb-metadata">
             <fieldset name="metadata" form="notebook">
             </fieldset>
@@ -86,28 +78,36 @@ the notebook experiennce from browse to edit/focus mode.
                 <button>Close</button>
             </form>
         </dialog>
-        {# skip to top is needed for long notebooks.
-        it is difficult to access for keyboard users. #}
-        <a href="#notebook" accesskey="0">skip to top</a>
-        </section>
-        {% include "semantic-forms/settings.html.j2" %}
-        <footer>
-            <fieldset>
-                <legend>application controls</legend>
-                <label for="nb-activate">edit mode</label>
-                <input id="nb-activate" type="checkbox">
-                <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
-            </fieldset>
-            <ol id="log" aria-relevant="additions"></ol>
-        </footer>
-        <script>
-            function openDialog(x) {
-                document.getElementById(x.getAttribute("aria-controls")).showModal();
-            };
+    </fieldset>
+    {# a notebook begins as a static document that can progressively
+    add features like run time computation. #}
+    <form name="notebook" id="notebook" aria-labelledby="nb-controls-label">
+        <fieldset disabled>
+            <legend id="nb-controls-label">Notebook Controls</legend>
+            <button type="submit">Run</button>
+        </fieldset>
+    </form>
+    {# skip to top is needed for long notebooks.
+    it is difficult to access for keyboard users. #}
+    <a href="#notebook" accesskey="0">skip to top</a>
+    {% include "semantic-forms/settings.html.j2" %}
+    <footer>
+        <fieldset>
+            <legend>application controls</legend>
+            <label for="nb-activate">edit mode</label>
+            <input id="nb-activate" type="checkbox">
+            <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
+        </fieldset>
+        <ol id="log" aria-relevant="additions"></ol>
+    </footer>
+    <script>
+        function openDialog(x) {
+            document.getElementById(x.getAttribute("aria-controls")).showModal();
+        };
 
-        </script>
-        <style id="nb-font-size-style"></style>
-        <style id="nb-font-family-style"></style>
+    </script>
+    <style id="nb-font-size-style"></style>
+    <style id="nb-font-family-style"></style>
 </body>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -83,10 +83,10 @@ the notebook experiennce from browse to edit/focus mode.
     {# a notebook begins as a static document that can progressively
     add features like run time computation. #}
     <form name="notebook" id="notebook" aria-labelledby="nb-controls-label">
-        <legend id="nb-controls-label">Notebook Controls</legend>
         <label for="nb-activate">edit mode</label>
         <input id="nb-activate" type="checkbox">
         <fieldset disabled>
+            <legend id="nb-controls-label">Notebook Controls</legend>
             <button type="submit">Run</button>
         </fieldset>
         <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -79,7 +79,7 @@ the notebook experiennce from browse to edit/focus mode.
             <form method="dialog">
                 <button>Close</button>
             </form>
-        </fieldset>
+    </fieldset>
     </dialog>
     {# a notebook begins as a static document that can progressively
     add features like run time computation. #}
@@ -152,6 +152,7 @@ In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span 
     <legend hidden id="cell-{{i}}-input">
         In {{execution_count}}
     </legend>
+    <label aria-hidden="true" for="cell-{{i}}-source">{{label}}</label>
     <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
         aria-labelledby="cell-{{i}}-input">{{source}}</textarea>
     {{highlight(source)}}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -78,31 +78,38 @@ the notebook experiennce from browse to edit/focus mode.
                 <button>Close</button>
             </form>
         </dialog>
+        <a href="#notebook" accesskey="0">skip to top</a>
     </fieldset>
     {# a notebook begins as a static document that can progressively
     add features like run time computation. #}
     <form name="notebook" id="notebook" aria-labelledby="nb-controls-label">
+        <legend id="nb-controls-label">Notebook Controls</legend>
+        <label for="nb-activate">edit mode</label>
+        <input id="nb-activate" type="checkbox">
         <fieldset disabled>
-            <legend id="nb-controls-label">Notebook Controls</legend>
             <button type="submit">Run</button>
         </fieldset>
+        <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
     </form>
     {# skip to top is needed for long notebooks.
     it is difficult to access for keyboard users. #}
-    <a href="#notebook" accesskey="0">skip to top</a>
     {% include "semantic-forms/settings.html.j2" %}
     <footer>
-        <fieldset>
-            <legend>application controls</legend>
-            <label for="nb-activate">edit mode</label>
-            <input id="nb-activate" type="checkbox">
-            <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
+        <fieldset name="log" id="log" role="log" aria-live="polite">
+            <legend>activity</legend>
         </fieldset>
-        <ol id="log" aria-relevant="additions"></ol>
     </footer>
     <script>
         function openDialog(x) {
             document.getElementById(x.getAttribute("aria-controls")).showModal();
+        };
+
+        function activityLog(msg, at = true) {
+            const body = document.querySelector("#log");
+            let out = document.createElement("output");
+            out.textContent = msg;
+            at ? null : out.setAttribute("aria-hidden", true);
+            body.append(out);
         };
     </script>
     <style id="nb-font-size-style"></style>
@@ -182,17 +189,17 @@ In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span 
 {% set label %}{% if CODE and outputs %}Out<span aria-hidden="true">[</span>{{execution_count}}<span
     aria-hidden="true">]</span>{% else %}Cell {{i}}{% endif %}{% endset %}
 <span hidden id="cell-{{i}}-outputs-len">{{outputs.__len__()}} outputs</span>
+{% if CODE and outputs %}
 <fieldset name="outputs" id="cell-{{i}}-outputs" aria-describedby="cell-{{i}}-outputs-len">
     <legend hidden>Out {{execution_count}}</legend>
     {% if outputs %}
     <span aria-hidden="true">{{label}}</span>
     {% endif %}
-    {% if CODE and outputs %}
     {{cell_display_priority(i, outputs, cell)}}
-    {% elif cell_type=="markdown" %}
-    {{ markdown(source) | strip_files_prefix }}
-    {% endif %}
 </fieldset>
+{% elif cell_type=="markdown" %}
+{{ markdown(source) | strip_files_prefix }}
+{% endif %}
 {%- endmacro -%}
 
 {#

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -39,13 +39,13 @@ the notebook experiennce from browse to edit/focus mode.
         <label aria-hidden="true" id="nb-skip-links-label">skip links</label>
         <ul role="toolbar">
             <li>
-                <a href="#cells" tabindex="0">skip to content</a>
+                <a href="#cells" tabindex="0" accesskey="1">skip to content</a>
             </li>
             <li>
-                <a href="#nb-toc">table of contents</a>
+                <a href="#nb-toc" accesskey="0">table of contents</a>
             </li>
             <li>
-                <button>settings & accessibility</button>
+            <button onclick="openDialog(this)" data-controls="nb-settings">Settings</button>
             </li>
         </ul>
     </header>
@@ -87,6 +87,7 @@ the notebook experiennce from browse to edit/focus mode.
         </footer>
     </main>
     <footer></footer>
+    {% include "semantic-forms/settings.html.j2" %}
 </body>
 <script>
     function setCookie(cname, cvalue, exdays) {

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -41,10 +41,10 @@ the notebook experiennce from browse to edit/focus mode.
 {% block body_header %}
 
 <body>
-    <section id="skip-link">
-        <a href="#cells" tabindex="0" accesskey="1">skip to main content</a>
-    </section>
     <header aria-label="site header">
+        <section id="skip-link">
+            <a href="#cells" tabindex="0" accesskey="1">skip to main content</a>
+        </section>
         {# the skip link is the first tab stop in the site to skip repetitive information
         and directly access the content. #}
         {# site authors with include their site specific headers in this region. #}
@@ -80,13 +80,11 @@ the notebook experiennce from browse to edit/focus mode.
                 <button>Close</button>
             </form>
         </dialog>
-        <a href="#notebook" accesskey="0">skip to top</a>
     </fieldset>
     {# a notebook begins as a static document that can progressively
     add features like run time computation. #}
     <form name="notebook" id="notebook" aria-labelledby="nb-controls-label">
-        <label for="nb-activate">edit mode</label>
-        <input id="nb-activate" type="checkbox">
+        <label><input type="checkbox">edit mode</label>
         <fieldset disabled>
             <legend id="nb-controls-label">Notebook Controls</legend>
             <button type="submit">Run</button>
@@ -99,6 +97,7 @@ the notebook experiennce from browse to edit/focus mode.
     <footer>
         <section id="log" role="log" aria-live="polite" aria-label="activity">
         </section>
+        <a href="#notebook" accesskey="0">skip to top</a>
     </footer>
     <script>
         function openDialog(x) {
@@ -164,7 +163,6 @@ In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span 
     <legend hidden id="cell-{{i}}-input">
         In {{execution_count}}
     </legend>
-    <label aria-hidden="true" for="cell-{{i}}-source">{{label}}</label>
     <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
         aria-labelledby="cell-{{i}}-input">{{source}}</textarea>
     {{highlight(source)}}

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -50,7 +50,8 @@ the notebook experiennce from browse to edit/focus mode.
     </header>
     {# this is the main section, but we want landmark navigation to go to the first cell in
     the notebook. the extending template will define the location of the main content. #}
-    <section id=notebook role="group">
+    <fieldset id="notebook">
+        <legend>notebook</legend>
         <section aria-labelledby="nb-toc">
             {# a notebook will provide visual structural navigation for a document.
             this is a feature of screen readers that is not common to sighted users.
@@ -86,23 +87,23 @@ the notebook experiennce from browse to edit/focus mode.
         {# skip to top is needed for long notebooks.
         it is difficult to access for keyboard users. #}
         <a href="#notebook" accesskey="0">skip to top</a>
-    </section>
-    {% include "semantic-forms/settings.html.j2" %}
-    <footer>
-        <fieldset>
-            <legend>application controls</legend>
-            <label for="nb-activate">edit mode</label>
-            <input id="nb-activate" type="checkbox">
-            <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
-        </fieldset>
-        <ol id="log" aria-relevant="additions"></ol>
-    </footer>
-    <script>
-        function openDialog(x) {
-            document.getElementById(x.getAttribute("aria-controls")).showModal();
-        };
+        </section>
+        {% include "semantic-forms/settings.html.j2" %}
+        <footer>
+            <fieldset>
+                <legend>application controls</legend>
+                <label for="nb-activate">edit mode</label>
+                <input id="nb-activate" type="checkbox">
+                <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
+            </fieldset>
+            <ol id="log" aria-relevant="additions"></ol>
+        </footer>
+        <script>
+            function openDialog(x) {
+                document.getElementById(x.getAttribute("aria-controls")).showModal();
+            };
 
-    </script>
+        </script>
 </body>
 
 </html>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -38,7 +38,7 @@ the notebook experiennce from browse to edit/focus mode.
 
 <body>
     <section id="skip-link">
-        <a href="#cells" tabindex="0" accesskey="1">skip to content</a>
+        <a href="#cells" tabindex="0" accesskey="1">skip to main content</a>
     </section>
     <header aria-label="site header">
         {# the skip link is the first tab stop in the site to skip repetitive information
@@ -46,7 +46,7 @@ the notebook experiennce from browse to edit/focus mode.
         {# site authors with include their site specific headers in this region. #}
         {# a subsequent tab stop will indicate to keyboard and AT users that there are
         accessibility settings that can be toggled. #}
-        <button onclick="openDialog(this)" aria-controls="nb-settings">Settings</button>
+        <button onclick="openDialog(this)" aria-controls="nb-settings" accesskey=",">Settings</button>
     </header>
     {# this is the main section, but we want landmark navigation to go to the first cell in
     the notebook. the extending template will define the location of the main content. #}
@@ -58,15 +58,16 @@ the notebook experiennce from browse to edit/focus mode.
             to skip the link tree. the best implementation is a tree that will consume a single tab stop
             and allow arrow key navigation. #}
             <details open>
+                {# if the label is on the summary then the bullet is announced as the label and it should not be #}
                 <summary><span id="nb-toc">table of contents</span></summary>
                 {# the table of contents is populated in python. #}
             </details>
         </section>
-        {% block main_header scoped %}
-        {% endblock main_header %}
-        {% endblock body_header %}
+        <main>
+            {% endblock body_header %}
 
-        {% block body_footer %}
+            {% block body_footer %}
+        </main>
         {# a notebook begins as a static document that can progressively
         add features like run time computation. #}
         <form name="notebook" aria-labelledby="nb-controls-label">
@@ -84,7 +85,7 @@ the notebook experiennce from browse to edit/focus mode.
         </dialog>
         {# skip to top is needed for long notebooks.
         it is difficult to access for keyboard users. #}
-        <a href="#notebook">skip to top</a>
+        <a href="#notebook" accesskey="0">skip to top</a>
     </section>
     {% include "semantic-forms/settings.html.j2" %}
     <footer>
@@ -94,7 +95,6 @@ the notebook experiennce from browse to edit/focus mode.
             <input id="nb-activate" type="checkbox">
             <button onclick="openDialog(this)" aria-controls="nb-metadata">Metadata</button>
         </fieldset>
-
         <ol id="log" aria-relevant="additions"></ol>
     </footer>
 </body>
@@ -104,9 +104,8 @@ the notebook experiennce from browse to edit/focus mode.
     };
 
     function toggleColorScheme(x) {
-        const scheme = document.querySelector(`head > meta[name="color-scheme"]`);
-        scheme.content = x.value;
-        // handle code theme, will have to do this will meramid
+        document.querySelector(`head > meta[name="color-scheme"]`).content = x.value;
+        {# handle code theme, will have to do this will meramid #}
         document.getElementById(`nb-${x.value}-theme`).setAttribute("media", "all");
         const opposite = x.value == "dark" ? "light" : "dark";
         document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none");

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -52,7 +52,7 @@ the notebook experiennce from browse to edit/focus mode.
     </header>
     {# this is the main section, but we want landmark navigation to go to the first cell in
     the notebook. the extending template will define the location of the main content. #}
-    <fieldset id="notebook">
+    <fieldset form="notebook">
         <legend>notebook</legend>
         <section aria-labelledby="nb-toc">
             {# a notebook will provide visual structural navigation for a document.
@@ -104,7 +104,6 @@ the notebook experiennce from browse to edit/focus mode.
         function openDialog(x) {
             document.getElementById(x.getAttribute("aria-controls")).showModal();
         };
-
     </script>
     <style id="nb-font-size-style"></style>
     <style id="nb-font-family-style"></style>

--- a/nbconvert_html5/templates/semantic-forms/base.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/base.html.j2
@@ -96,8 +96,8 @@ the notebook experiennce from browse to edit/focus mode.
     {% include "semantic-forms/settings.html.j2" %}
     <footer>
         <fieldset form="notebook" name="log">
-            <section class="activityLog" role="log" aria-live="polite">
-            </section>
+            <ul class="activityLog" role="log" aria-live="polite">
+            </ul>
         </fieldset>
         <a href="#notebook" accesskey="0">skip to top</a>
     </footer>

--- a/nbconvert_html5/templates/semantic-forms/displays.j2.html
+++ b/nbconvert_html5/templates/semantic-forms/displays.j2.html
@@ -1,0 +1,149 @@
+{%- extends 'display_priority.j2' -%}
+
+{% block execute_result -%}
+{%- set extra_class="output_execute_result" -%}
+{% block data_priority scoped %}
+{{ super() }}
+{% endblock data_priority %}
+{%- set extra_class="" -%}
+{%- endblock execute_result %}
+
+{% block stream_stdout -%}
+<pre class="stdout">
+<code>{{- output.text -}}</code>
+</pre>
+{%- endblock stream_stdout %}
+
+{% block stream_stderr -%}
+<pre class="stdout">
+<code>{{- output.text -}}</code>
+</pre>
+{%- endblock stream_stderr %}
+
+{% block data_svg scoped -%}
+{%- if output.svg_filename %}
+<img src="{{ output.svg_filename | posix_path | escape_html }}">
+{%- else %}
+{{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
+{%- endif %}
+{%- endblock data_svg %}
+
+{% block data_html scoped -%}
+{%- if resources.should_sanitize_html %}
+{%- set html_value=output.data['text/html'] | clean_html -%}
+{%- else %}
+{%- set html_value=output.data['text/html'] -%}
+{%- endif %}
+{%- if output.get('metadata', {}).get('text/html', {}).get('isolated') -%}
+<iframe class="isolated-iframe" style="height:520px; width:100%; margin:0; padding: 0" frameborder="0" scrolling="auto"
+    src="data:text/html;base64,{{ html_value | text_base64 }}">
+</iframe>
+{%- else -%}
+{{ html_value }}
+{%- endif -%}
+{%- endblock data_html %}
+
+{% block data_markdown scoped -%}
+{%- if resources.should_sanitize_html %}
+{%- set html_value=output.data['text/markdown'] | markdown2html | clean_html -%}
+{%- else %}
+{%- set html_value=output.data['text/markdown'] | markdown2html -%}
+{%- endif %}
+{{ html_value }}
+{%- endblock data_markdown %}
+
+{% block data_png scoped %}
+{# <figure class="png"> #}
+    {%- if 'image/png' in output.metadata.get('filenames', {}) %}
+    <img src="{{ output.metadata.filenames['image/png'] | posix_path | escape_html }}" {%- else %} <img
+        src="data:image/png;base64,{{ output.data['image/png'] | escape_html }}" {%- endif %} {%- set width=output |
+        get_metadata('width', 'image/png' ) -%} {%- if width is not none %} width={{ width | escape_html }} {%- endif %}
+        {%- set height=output | get_metadata('height', 'image/png' ) -%} {%- if height is not none %} height={{ height |
+        escape_html }} {%- endif %} {%- if output | get_metadata('unconfined', 'image/png' ) %} class="unconfined" {%-
+        endif %} {%- set alttext=(output | get_metadata('alt', 'image/png' )) or (cell | get_metadata('alt')) -%} {%- if
+        alttext is not none %} alt="{{ alttext | escape_html }}" {%- endif %}>
+    {#
+</figure> #}
+{%- endblock data_png %}
+
+{% block data_jpg scoped %}
+{# <figure class="jpeg jpg"> #}
+    {%- if 'image/jpeg' in output.metadata.get('filenames', {}) %}
+    <img src="{{ output.metadata.filenames['image/jpeg'] | posix_path | escape_html }}" {%- else %} <img
+        src="data:image/jpeg;base64,{{ output.data['image/jpeg'] | escape_html }}" {%- endif %} {%- set width=output |
+        get_metadata('width', 'image/jpeg' ) -%} {%- if width is not none %} width={{ width | escape_html }} {%- endif
+        %} {%- set height=output | get_metadata('height', 'image/jpeg' ) -%} {%- if height is not none %} height={{
+        height | escape_html }} {%- endif %} {%- if output | get_metadata('unconfined', 'image/jpeg' ) %}
+        class="unconfined" {%- endif %} {%- set alttext=(output | get_metadata('alt', 'image/jpeg' )) or (cell |
+        get_metadata('alt')) -%} {%- if alttext is not none %} alt="{{ alttext | escape_html }}" {%- endif %}>
+    {#
+</figure> #}
+{%- endblock data_jpg %}
+
+{% block data_latex scoped %}
+{# <figure class="latex"> #}
+    {{ output.data['text/latex'] | e }}
+    {# </figure> #}
+{%- endblock data_latex %}
+
+{% block error -%}
+<pre class="exception">
+{{- super() -}}
+</pre>
+{%- endblock error %}
+
+{%- block traceback_line %}
+{{ line | ansi2html }}
+{%- endblock traceback_line %}
+
+{%- block data_text scoped %}
+<pre class="plain">
+{{- output.data['text/plain'] | ansi2html -}}
+</pre>
+{%- endblock -%}
+
+{%- block data_javascript scoped %}
+{% set div_id = uuid4() %}
+<div id="{{ div_id }}" class="output_subarea output_javascript {{ extra_class }}">
+    {%- if not resources.should_sanitize_html %}
+    <script type="text/javascript">
+        var element = $('#{{ div_id }}');
+        { { output.data['application/javascript'] } }
+    </script>
+    {%- endif %}
+</div>
+{%- endblock -%}
+
+{%- block data_widget_view scoped %}
+{%- if not resources.should_sanitize_html %}
+{% set div_id = uuid4() %}
+{% set datatype_list = output.data | filter_data_type %}
+{% set datatype = datatype_list[0]%}
+<div id="{{ div_id }}" class="output_subarea output_widget_view {{ extra_class }}">
+    <script type="text/javascript">
+        var element = $('#{{ div_id }}');
+    </script>
+    <script type="{{ datatype }}">
+{{ output.data[datatype] | json_dumps | escape_html }}
+</script>
+</div>
+{%- endif %}
+{%- endblock data_widget_view -%}
+
+{%- block footer %}
+{%- if not resources.should_sanitize_html %}
+{% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
+{% if mimetype in nb.metadata.get("widgets",{})%}
+<script type="{{ mimetype }}">
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html }}
+</script>
+{% endif %}
+{%- endif %}
+{{ super() }}
+{%- endblock footer-%}
+
+{%- macro cell_display_priority(i, outputs, cell) -%}
+{%- for i, output in enumerate(outputs) -%}
+{%- block output scoped -%}{{super()}}{%- endblock -%}
+{%- endfor -%}
+{%- endmacro -%}

--- a/nbconvert_html5/templates/semantic-forms/feed.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/feed.html.j2
@@ -1,13 +1,16 @@
-{%- extends 'semantic-forms/index.html.j2' -%}
+{%- extends 'semantic-forms/main.html.j2' -%}
 {% from 'mathjax.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
-{% block body_loop %}
-<section role="feed">{{super()}}</section>
-{% endblock body_loop %}
+{% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
-{% block any_cell %}
-<article class="cell {{cell.cell_type}} {{celltags(cell)}}">
-{{cell_form(cell, nb)}}
+{% block body_header %}
+{{super()}}
+<article role="feed">
+    {{super()}}
+    {% endblock body_header %}
+
+    {% block body_footer %}
 </article>
-{% endblock any_cell %}
+{{super()}}
+{% endblock body_footer %}

--- a/nbconvert_html5/templates/semantic-forms/main.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/main.html.j2
@@ -1,50 +1,14 @@
 {%- extends 'semantic-forms/base.html.j2' -%}
 {% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
-{%- block header -%}
-<!DOCTYPE html>
-<html lang="en">
 
-<head>
-    {%- block head -%}
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{title}}</title>
-    <meta name="color-scheme" content="dark light">
+{% block main_header scoped %}
+{{super()}} 
+<fieldset name="cells" form="notebook" disabled>
+    <legend>cells</legend>
+    {% endblock main_header %}
 
-    <link rel="stylesheet" href="style.css">
-    {%- endblock head -%}
-    {%- block html_head_js_mathjax -%}{%- endblock html_head_js_mathjax -%}
-</head>
-{%- endblock header -%}
-
-{% block any_cell %}{{cell_section(cell, loop)}}{% endblock any_cell %}
-
-{% block body_header %}
-
-<body>
-    <header class="site">
-        {% block skip_links %}
-        <a class="visually-hidden" tabindex="0" href="#/" >Skip to content</a>
-        {% endblock skip_links %}
-    </header>
-    <main id="/" aria-labelledby=title>
-        {% block main_header scoped %}
-        <form name="notebook" aria-labelledby="nb-controls-label">
-            <fieldset>
-                <legend id="nb-controls-label">Notebook Controls</legend>
-                <button type="submit">Run All</button>
-            </fieldset>
-        </form>
-        <details id="toc">
-            <summary id="title" accesskey="0">{{title}}</summary>
-        </details>
-        {% endblock main_header %}
-        {% endblock body_header %}
-
-        {% block body_footer %}
-    </main>
-</body>
-
-</html>
+    {% block body_footer %}
+</fieldset>
+{{super()}}
 {% endblock body_footer %}

--- a/nbconvert_html5/templates/semantic-forms/main.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/main.html.j2
@@ -15,19 +15,10 @@
     <link rel="stylesheet" href="style.css">
     {%- endblock head -%}
     {%- block html_head_js_mathjax -%}{%- endblock html_head_js_mathjax -%}
-
 </head>
-{%- endblock -%}
+{%- endblock header -%}
 
-
-{% block body_loop %}
-<ol>{{super() }}</ol> {% endblock body_loop %}
-
-{% block any_cell %}
-<li class="cell {{cell.cell_type}} {{celltags(cell)}}">
-    {{cell_section(cell, loop)}}
-</li>
-{% endblock any_cell %}
+{% block any_cell %}{{cell_section(cell, loop)}}{% endblock any_cell %}
 
 {% block body_header %}
 
@@ -38,10 +29,17 @@
         {% endblock skip_links %}
     </header>
     <main id="/" aria-labelledby=title>
-        <form name="notebook"></form>
+        {% block main_header scoped %}
+        <form name="notebook" aria-labelledby="nb-controls-label">
+            <fieldset>
+                <legend id="nb-controls-label">Notebook Controls</legend>
+                <button type="submit">Run All</button>
+            </fieldset>
+        </form>
         <details id="toc">
             <summary id="title">{{title}}</summary>
         </details>
+        {% endblock main_header %}
         {% endblock body_header %}
 
         {% block body_footer %}

--- a/nbconvert_html5/templates/semantic-forms/main.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/main.html.j2
@@ -25,7 +25,7 @@
 <body>
     <header class="site">
         {% block skip_links %}
-        <a class="visually-hidden" tabindex="0" href="#/">Skip to content</a>
+        <a class="visually-hidden" tabindex="0" href="#/" >Skip to content</a>
         {% endblock skip_links %}
     </header>
     <main id="/" aria-labelledby=title>
@@ -37,7 +37,7 @@
             </fieldset>
         </form>
         <details id="toc">
-            <summary id="title">{{title}}</summary>
+            <summary id="title" accesskey="0">{{title}}</summary>
         </details>
         {% endblock main_header %}
         {% endblock body_header %}

--- a/nbconvert_html5/templates/semantic-forms/ol.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/ol.html.j2
@@ -1,6 +1,20 @@
 {%- extends 'semantic-forms/base.html.j2' -%}
 {% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
+{% macro cell_section(cell, loop) %}
+<section class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
+    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
+    data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
+    {{cell_anchor(loop.index)}}
+    {{cell_form(i)}}
+    {{cell_execution_count(loop.index, cell.execution_count)}}
+    {{cell_cell_type(loop.index, cell.cell_type)}}
+    {{cell_source(loop.index, cell.source, cell.execution_count)}}
+    {{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type, cell.execution_count)}}
+    {{cell_metadata(loop.index, cell.metadata)}}
+</section>
+{% endmacro%}
+
 {%- block header -%}
 <!DOCTYPE html>
 <html lang="en">
@@ -21,10 +35,10 @@
 
 
 {% block body_loop %}
-<ol>{{super() }}</ol> {% endblock body_loop %}
+<ol id=cells>{{super() }}</ol> {% endblock body_loop %}
 
 {% block any_cell %}
-<li class="cell {{cell.cell_type}} {{celltags(cell)}}">
+<li>
     {{cell_section(cell, loop)}}
 </li>
 {% endblock any_cell %}
@@ -50,3 +64,5 @@
 
 </html>
 {% endblock body_footer %}
+
+

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -1,20 +1,23 @@
 <dialog id="nb-settings">
     <h1 role="presentation">Settings</h1>
-    <form method="dialog">
-        <button type="submit">Close</button>
+    <form>
+        <button formmethod="dialog">Close</button>
     </form>
     <fieldset id="nb-color-scheme-radio">
         <legend>color scheme</legend>
         <span aria-hidden="true">color scheme</span>
         <label>light mode<input value="light" name="color-scheme" type="radio" checked></label>
-        <label>>dark mode<input value="dark" name="color-scheme" type="radio"></label>
+        <label>dark mode<input value="dark" name="color-scheme" type="radio"></label>
     </fieldset>
     <fieldset id="nb-table-role-radio">
         <legend>cell navigation</legend>
-        <span aria-hidden="true">cell navigation</span>
+        <b aria-hidden="true">cell navigation</b>
+        <i>modify the screen reader's cell navigation preference,
+            there is no effect on the visual layout.</i>
         <label>list<input value="list" name="table-role" type="radio" checked></label>
         <label>table<input value="table" name="table-role" type="radio"></label>
-        <label>landmark<input value="region" name="table-role" type="radio"></label>
+        <label>landmark<input value="landmark" name="table-role" type="radio"></label>
+        <label>presentation<input value="presentation" name="table-role" type="radio"></label>
         <label>grid<input value="grid" name="table-role" type="radio" disabled></label>
         <label>treegrid<input value="treegrid" name="table-role" type="radio" disabled></label>
         <label>tree<input value="tree" name="table-role" type="radio" disabled></label>
@@ -33,10 +36,14 @@
         </select>
         <fieldset id="nb-font-serif-radio">
             <legend>serif</legend>
-            <label>serif<input value="serif" name="font-family" type="radio" checked>s</label>
+            <label>serif<input value="serif" name="font-family" type="radio" checked></label>
             <label>sans-serif<input value="sans-serif" name="font-family" type="radio"></label>
         </fieldset>
         <span hidden id="nb-def-cell">cell</span>
+    </fieldset>
+    <fieldset form="notebook" name="log">
+        <section class="activityLog" role="log" aria-live="polite">
+        </section>
     </fieldset>
 </dialog>
 
@@ -63,13 +70,13 @@
             "row": null,
             "header": null,
             "cell": null,
-        }, "region": {
+        }, "landmark": {
             "table": "presentation",
             "body": "group",
             "row": "region",
             "header": "none",
             "cell": "none",
-        }, "generic": {
+        }, "presentation": {
             "table": "presentation",
             "body": "none",
             "row": "none",
@@ -83,6 +90,7 @@
         let opposite = event.target.value == "dark" ? "light" : "dark"
         document.getElementById(`nb-${opposite}-theme`).setAttribute("disabled", null);
         document.querySelector(`head > meta[name="color-scheme"]`).setAttribute("content", event.target.value);
+        activityLog(`${event.target.value} mode activated`)
     }
     document.querySelectorAll(`[name="color-scheme"]`).forEach(
         (x) => { x.addEventListener("change", toggleColorScheme) }
@@ -100,8 +108,8 @@
                         }
                     }
                 );
-                k == `table` ? activityLog(`navigate cells as a ${event.target.value}`) : null;
             }
+            activityLog(`notebook cell navigation set to ${event.target.value}.`);
         }
     }
     document.querySelectorAll(`[name="table-role"]`).forEach(
@@ -109,15 +117,30 @@
     )
     function changeFont() {
         document.getElementById("nb-font-size-style").textContent = `:root {--nb-font-size: ${event.target.value};}`
+        activityLog(`font size change`)
     }
     document.querySelectorAll(`[name="font-size"]`).forEach(
         (x) => { x.addEventListener("change", changeFont) }
     )
     function changeFontFamily() {
-        document.getElementById("nb-font-family-style").textContent = `:root {font-family: ${event.target.value};}`
+        document.getElementById("nb-font-family-style").textContent = `:root {font-family: ${event.target.value};}`;
+        activityLog(`font family change`)
     }
     document.querySelectorAll(`[name="font-family"]`).forEach(
         (x) => { x.addEventListener("change", changeFontFamily) }
     )
+    function activityLog(msg, silent = false) {
+        document.querySelectorAll(".activityLog").forEach(
+            (body) => {
+                let li = document.createElement("li"), out = document.createElement("output");
+                out.textContent = msg;
+                silent ? out.setAttribute("aria-hidden", true) : null;
+                li.append(out);
+                body.append(li);
+            }
+        )
+
+    };
+
 </script>
 {% endraw %}

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -1,54 +1,114 @@
 <dialog id="nb-settings">
     <h1>Settings</h1>
-    <label for="nb-color-theme-switcher">Switch color scheme</label>
-    <select onchange="toggleColorScheme(this)" id="nb-color-theme-switcher">
-        <option value="light">light mode</option>
-        <option value="dark">dark mode</option>
-    </select>
-    {# <details open>
-        <summary>Labels</summary>
-        <label>Cell numbers.</label><input type="checkbox" checked />
-        <label>Line numbers</label><input type="checkbox" disabled />
-    </details>
-    <details open>
-        <summary>Text</summary>
-        <label>Font size</label>
-        <optgroup>
-            <select>small</select>
-            <select>medium</select>
-            <select>large</select>
-        </optgroup>
-        <label>Letter spacing</label><input type="checkbox" />
-        <label>Word spacing</label><input type="checkbox" />
-        <label>Line spacing</label><input type="checkbox" />
-        <label>Serif</label><input type="checkbox" />
-    </details>
-    <details open>
-        <summary>Assistive technology</summary>
-        <label>Cells landmarks</label><input type="checkbox" checked />
-        <label>Semantic code grouping</label><input type="checkbox" checked />
-        <label>Notebook layout</label>
-        <optgroup>
-            <select>document</select>
-            <select>feed</select>
-            <select>list</select>
-            <select>table</select>
-            <select disabled>grid</select>
-            <select disabled>treegrid</select>
-        </optgroup>
-    </details>
-    <details>
-        <summary>Custom css</summary>
-        <textarea disabled></textarea>
-    </details>
     <form method="dialog">
         <button type="submit">Close</button>
-    </form> #}
-    <h2>Terminology</h2>
-    <dl>
-        <dt id="nb-def-cell">cell</dt>
-        <dd>units of the notebooks that contain source code and output.</dd>
-    </dl>
+    </form>
+    <fieldset id="nb-color-scheme-radio">
+        <legend>color scheme</legend>
+        <label aria-hidden="true" for="nb-color-theme-radio">color scheme</label>
+        <label><input value="light" name="color-scheme" type="radio" checked> light mode</label>
+        <label><input value="dark" name="color-scheme" type="radio"> dark mode</label>
+    </fieldset>
+    <fieldset id="nb-table-role-radio">
+        <legend>cell navigation</legend>
+        <label aria-hidden="true" for="nb-table-role-radio">cell navigation</label>
+        <label><input value="list" name="table-role" type="radio" checked> list</label>
+        <label><input value="table" name="table-role" type="radio"> table</label>
+        <label><input value="region" name="table-role" type="radio"> landmark</label>
+        <label><input value="grid" name="table-role" type="radio" disabled> grid</label>
+        <label><input value="treegrid" name="table-role" type="radio" disabled> treegrid</label>
+        <label><input value="tree" name="table-role" type="radio" disabled> tree</label>
+    </fieldset>
+    <fieldset id="nb-table-font-group">
+        <legend>font settings</legend>
+        <label aria-hidden="true" for="nb-table-font-size-group">font size</label>
+        <select name="font-size" id="nb-table-font-size-group">
+            <option value="xx-small">xx-small</label>
+            <option value="x-small">x-small</label>
+            <option value="small">small</label>
+            <option value="medium" selected>medium</label>
+            <option value="large">large</label>
+            <option value="x-large">x-large</label>
+            <option value="xx-large">xx-large</label>
+        </select>
+        <style id="nb-font-size-style"></style>
+        <fieldset id="nb-font-serif-radio">
+            <legend>serif</legend>
+            <label><input value="serif" name="font-family" type="radio" checked> serif</label>
+            <label><input value="sans-serif" name="font-family" type="radio"> sans-serif</label>
+        </fieldset>
+        <style id="nb-font-family-style"></style>
+        <span hidden id="nb-def-cell">cell</span>
+    </fieldset>
 </dialog>
 
 {# these settings should be updated from query parameters #}
+
+{% raw %}
+<script>
+    const SELECTORS = {
+        "table": "table#cells",
+        "body": "table#cells>tbody",
+        "row": "table#cells>tbody>tr",
+        "cell": "table#cells>tbody>tr>th,table#cells>tbody>tr>td",
+    }, ROLES = {
+        "list": {
+            "table": "group",
+            "body": "list",
+            "row": "listitem",
+            "cell": "none",
+        }, "table": {
+            "table": "table",
+            "body": "rowgroup",
+            "row": "row",
+            "cell": "cell",
+        }, "region": {
+            "table": "group",
+            "body": "group",
+            "row": "region",
+            "cell": "none",
+        }, "generic": {
+            "table": "group",
+            "body": "none",
+            "row": "none",
+            "cell": "none",
+        }
+    };
+
+    function toggleColorScheme() {
+        document.getElementById(`nb-${event.target.value}-theme`).setAttribute("media", "all");
+        let opposite = event.target.value == "dark" ? "light" : "dark"
+        document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none");
+        document.querySelector(`head > meta[name="color-scheme"]`).setAttribute("content", event.target.value);
+    }
+    document.querySelectorAll("#nb-color-scheme-radio>label>input").forEach(
+        (x) => { x.addEventListener("change", toggleColorScheme) }
+    )
+    function toggleRole() {
+        if (event.target.checked) {
+            for (const [k, selector] of Object.entries(SELECTORS)) {
+                document.querySelectorAll(selector).forEach(
+                    (x) => { x.setAttribute("role", ROLES[event.target.value][k]) }
+                )
+            }
+        }
+    }
+    document.querySelectorAll("#nb-table-role-radio>label>input").forEach(
+        (x) => { x.addEventListener("change", toggleRole) }
+    )
+    function changeFont() {
+        document.getElementById("nb-font-size-style").textContent = `:root {--nb-font-size: ${event.target.value};}`
+    }
+    document.querySelectorAll(`select[name="font-size"]`).forEach(
+        (x) => { x.addEventListener("change", changeFont) }
+    )
+
+    function changeFontFamily() {
+        document.getElementById("nb-font-size-style").textContent = `:root {font-family: ${event.target.value};}`
+    }
+    document.querySelectorAll(`[name="font-family"]`).forEach(
+        (x) => { x.addEventListener("change", changeFontFamily) }
+    )
+
+</script>
+{% endraw %}

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -42,8 +42,8 @@
         <span hidden id="nb-def-cell">cell</span>
     </fieldset>
     <fieldset form="notebook" name="log">
-        <section class="activityLog" role="log" aria-live="polite">
-        </section>
+        <ul class="activityLog" role="log" aria-live="polite">
+        </ul>
     </fieldset>
 </dialog>
 

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -1,9 +1,9 @@
 <dialog id="settings">
     <h1>Settings</h1>
-    <label>Color scheme</label>
-    <select onchange="toggleColorScheme(this)">
-        <option value="dark">dark</option>
-        <option value="light">light</option>
+    <label for="nb-color-theme-switcher">Switch color scheme</label>
+    <select onchange="toggleColorScheme(this)" id="nb-color-theme-switcher">
+        <option value="dark">dark mode</option>
+        <option value="light">light mode</option>
     </select>
     <details open>
         <summary>Labels</summary>
@@ -44,7 +44,11 @@
     <form method="dialog">
         <button type="submit">Close</button>
     </form>
-    </form>
+    <h2>Terminology</h2>
+    <dl>
+        <dt id="nb-def-cell">cell</dt>
+        <dd>units of the notebooks that contain source code and output.</dd>
+    </dl>
 </dialog>
 <button onclick="openDialog(this)" data-controls="settings">Settings</button>
 

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -52,7 +52,7 @@
         "cell": "table#cells>tbody>tr>td",
     }, ROLES = {
         "list": {
-            "table": "group",
+            "table": "presentation",
             "body": "list",
             "row": "listitem",
             "header": "none",
@@ -64,13 +64,13 @@
             "header": null,
             "cell": null,
         }, "region": {
-            "table": "group",
+            "table": "presentation",
             "body": "group",
             "row": "region",
             "header": "none",
             "cell": "none",
         }, "generic": {
-            "table": "group",
+            "table": "presentation",
             "body": "none",
             "row": "none",
             "header": "none",

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -95,7 +95,6 @@
     document.querySelectorAll(`[name="color-scheme"]`).forEach(
         (x) => { x.addEventListener("change", toggleColorScheme) }
     )
-    function activityLog(msg) { }
     function toggleRole() {
         if (event.target.checked) {
             for (const [k, selector] of Object.entries(SELECTORS)) {
@@ -140,6 +139,10 @@
             }
         )
 
+    };
+    function openDialog() {
+        event.preventDefault();
+        document.getElementById(event.target.getAttribute("aria-controls")).showModal();
     };
 
 </script>

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -42,7 +42,7 @@
         <span hidden id="nb-def-cell">cell</span>
     </fieldset>
     <fieldset form="notebook" name="log">
-        <ul class="activityLog" role="log" aria-live="polite">
+        <ul class="activityLog" aria-live="polite">
         </ul>
     </fieldset>
 </dialog>

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -1,4 +1,4 @@
-<dialog id="settings">
+<dialog id="nb-settings">
     <h1>Settings</h1>
     <label for="nb-color-theme-switcher">Switch color scheme</label>
     <select onchange="toggleColorScheme(this)" id="nb-color-theme-switcher">
@@ -50,6 +50,5 @@
         <dd>units of the notebooks that contain source code and output.</dd>
     </dl>
 </dialog>
-<button onclick="openDialog(this)" data-controls="settings">Settings</button>
 
 {# these settings should be updated from query parameters #}

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -31,13 +31,11 @@
             <option value="x-large">x-large</option>
             <option value="xx-large">xx-large</option>
         </select>
-        <style id="nb-font-size-style"></style>
         <fieldset id="nb-font-serif-radio">
             <legend>serif</legend>
             <label><input value="serif" name="font-family" type="radio" checked> serif</label>
             <label><input value="sans-serif" name="font-family" type="radio"> sans-serif</label>
         </fieldset>
-        <style id="nb-font-family-style"></style>
         <span hidden id="nb-def-cell">cell</span>
     </fieldset>
 </dialog>
@@ -50,27 +48,32 @@
         "table": "table#cells",
         "body": "table#cells>tbody",
         "row": "table#cells>tbody>tr",
-        "cell": "table#cells>tbody>tr>th,table#cells>tbody>tr>td",
+        "heading": "table#cells>tbody>tr>th",
+        "cell": "table#cells>tbody>tr>td",
     }, ROLES = {
         "list": {
             "table": "group",
             "body": "list",
             "row": "listitem",
+            "header": "none",
             "cell": "none",
         }, "table": {
             "table": "table",
             "body": null,
             "row": null,
+            "header": null,
             "cell": null,
         }, "region": {
             "table": "group",
             "body": "group",
             "row": "region",
+            "header": "none",
             "cell": "none",
         }, "generic": {
             "table": "group",
             "body": "none",
             "row": "none",
+            "header": "none",
             "cell": "none",
         }
     };

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -87,6 +87,7 @@
     document.querySelectorAll(`[name="color-scheme"]`).forEach(
         (x) => { x.addEventListener("change", toggleColorScheme) }
     )
+    function activityLog(msg){}
     function toggleRole() {
         if (event.target.checked) {
             for (const [k, selector] of Object.entries(SELECTORS)) {
@@ -99,7 +100,7 @@
                         }
                     }
                 );
-                k == `table` ? log(`navigate cells as a ${event.target.value}`) : null;
+                k == `table` ? activityLog(`navigate cells as a ${event.target.value}`) : null;
             }
         }
     }

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -6,8 +6,8 @@
     <fieldset id="nb-color-scheme-radio">
         <legend>color scheme</legend>
         <label aria-hidden="true" for="nb-color-theme-radio">color scheme</label>
-        <label><input value="light" name="color-scheme" type="radio" checked> light mode</label>
-        <label><input value="dark" name="color-scheme" type="radio"> dark mode</label>
+        <label><input value="light" name="color-scheme" type="radio" checked>light mode</label>
+        <label><input value="dark" name="color-scheme" type="radio">dark mode</label>
     </fieldset>
     <fieldset id="nb-table-role-radio">
         <legend>cell navigation</legend>
@@ -59,9 +59,9 @@
             "cell": "none",
         }, "table": {
             "table": "table",
-            "body": "rowgroup",
-            "row": "row",
-            "cell": "cell",
+            "body": null,
+            "row": null,
+            "cell": null,
         }, "region": {
             "table": "group",
             "body": "group",
@@ -84,12 +84,17 @@
     document.querySelectorAll(`[name="color-scheme"]`).forEach(
         (x) => { x.addEventListener("change", toggleColorScheme) }
     )
-
     function toggleRole() {
         if (event.target.checked) {
             for (const [k, selector] of Object.entries(SELECTORS)) {
                 document.querySelectorAll(selector).forEach(
-                    (x) => { x.setAttribute("role", ROLES[event.target.value][k]) }
+                    (x) => {
+                        if (ROLES[event.target.value][k] == null) {
+                            x.removeAttribute("role")
+                        } else {
+                            x.setAttribute("role", ROLES[event.target.value][k])
+                        }
+                    }
                 )
             }
         }
@@ -109,6 +114,5 @@
     document.querySelectorAll(`[name="font-family"]`).forEach(
         (x) => { x.addEventListener("change", changeFontFamily) }
     )
-
 </script>
 {% endraw %}

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -12,12 +12,12 @@
     <fieldset id="nb-table-role-radio">
         <legend>cell navigation</legend>
         <label aria-hidden="true" for="nb-table-role-radio">cell navigation</label>
-        <label><input value="list" name="table-role" type="radio" checked> list</label>
-        <label><input value="table" name="table-role" type="radio"> table</label>
-        <label><input value="region" name="table-role" type="radio"> landmark</label>
-        <label><input value="grid" name="table-role" type="radio" disabled> grid</label>
-        <label><input value="treegrid" name="table-role" type="radio" disabled> treegrid</label>
-        <label><input value="tree" name="table-role" type="radio" disabled> tree</label>
+        <label><input value="list" name="table-role" type="radio" checked>list</label>
+        <label><input value="table" name="table-role" type="radio">table</label>
+        <label><input value="region" name="table-role" type="radio">landmark</label>
+        <label><input value="grid" name="table-role" type="radio" disabled>grid</label>
+        <label><input value="treegrid" name="table-role" type="radio" disabled>treegrid</label>
+        <label><input value="tree" name="table-role" type="radio" disabled>tree</label>
     </fieldset>
     <fieldset id="nb-table-font-group">
         <legend>font settings</legend>
@@ -104,7 +104,7 @@
         (x) => { x.addEventListener("change", changeFont) }
     )
     function changeFontFamily() {
-        document.getElementById("nb-font-size-style").textContent = `:root {font-family: ${event.target.value};}`
+        document.getElementById("nb-font-family-style").textContent = `:root {font-family: ${event.target.value};}`
     }
     document.querySelectorAll(`[name="font-family"]`).forEach(
         (x) => { x.addEventListener("change", changeFontFamily) }

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -1,0 +1,51 @@
+<dialog id="settings">
+    <h1>Settings</h1>
+    <label>Color scheme</label>
+    <select onchange="toggleColorScheme(this)">
+        <option value="dark">dark</option>
+        <option value="light">light</option>
+    </select>
+    <details open>
+        <summary>Labels</summary>
+        <label>Cell numbers.</label><input type="checkbox" checked />
+        <label>Line numbers</label><input type="checkbox" disabled />
+    </details>
+    <details open>
+        <summary>Text</summary>
+        <label>Font size</label>
+        <optgroup>
+            <select>small</select>
+            <select>medium</select>
+            <select>large</select>
+        </optgroup>
+        <label>Letter spacing</label><input type="checkbox" />
+        <label>Word spacing</label><input type="checkbox" />
+        <label>Line spacing</label><input type="checkbox" />
+        <label>Serif</label><input type="checkbox" />
+    </details>
+    <details open>
+        <summary>Assistive technology</summary>
+        <label>Cells landmarks</label><input type="checkbox" checked />
+        <label>Semantic code grouping</label><input type="checkbox" checked />
+        <label>Notebook layout</label>
+        <optgroup>
+            <select>document</select>
+            <select>feed</select>
+            <select>list</select>
+            <select>table</select>
+            <select disabled>grid</select>
+            <select disabled>treegrid</select>
+        </optgroup>
+    </details>
+    <details>
+        <summary>Custom css</summary>
+        <textarea disabled></textarea>
+    </details>
+    <form method="dialog">
+        <button type="submit">Close</button>
+    </form>
+    </form>
+</dialog>
+<button onclick="openDialog(this)" data-controls="settings">Settings</button>
+
+{# these settings should be updated from query parameters #}

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -2,10 +2,10 @@
     <h1>Settings</h1>
     <label for="nb-color-theme-switcher">Switch color scheme</label>
     <select onchange="toggleColorScheme(this)" id="nb-color-theme-switcher">
-        <option value="dark">dark mode</option>
         <option value="light">light mode</option>
+        <option value="dark">dark mode</option>
     </select>
-    <details open>
+    {# <details open>
         <summary>Labels</summary>
         <label>Cell numbers.</label><input type="checkbox" checked />
         <label>Line numbers</label><input type="checkbox" disabled />
@@ -43,7 +43,7 @@
     </details>
     <form method="dialog">
         <button type="submit">Close</button>
-    </form>
+    </form> #}
     <h2>Terminology</h2>
     <dl>
         <dt id="nb-def-cell">cell</dt>

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -6,18 +6,18 @@
     <fieldset id="nb-color-scheme-radio">
         <legend>color scheme</legend>
         <span aria-hidden="true">color scheme</span>
-        <label><input value="light" name="color-scheme" type="radio" checked>light mode</label>
-        <label><input value="dark" name="color-scheme" type="radio">dark mode</label>
+        <label>light mode<input value="light" name="color-scheme" type="radio" checked></label>
+        <label>>dark mode<input value="dark" name="color-scheme" type="radio"></label>
     </fieldset>
     <fieldset id="nb-table-role-radio">
         <legend>cell navigation</legend>
         <span aria-hidden="true">cell navigation</span>
-        <label><input value="list" name="table-role" type="radio" checked>list</label>
-        <label><input value="table" name="table-role" type="radio">table</label>
-        <label><input value="region" name="table-role" type="radio">landmark</label>
-        <label><input value="grid" name="table-role" type="radio" disabled>grid</label>
-        <label><input value="treegrid" name="table-role" type="radio" disabled>treegrid</label>
-        <label><input value="tree" name="table-role" type="radio" disabled>tree</label>
+        <label>list<input value="list" name="table-role" type="radio" checked></label>
+        <label>table<input value="table" name="table-role" type="radio"></label>
+        <label>landmark<input value="region" name="table-role" type="radio"></label>
+        <label>grid<input value="grid" name="table-role" type="radio" disabled></label>
+        <label>treegrid<input value="treegrid" name="table-role" type="radio" disabled></label>
+        <label>tree<input value="tree" name="table-role" type="radio" disabled></label>
     </fieldset>
     <fieldset id="nb-table-font-group">
         <legend>font settings</legend>
@@ -33,8 +33,8 @@
         </select>
         <fieldset id="nb-font-serif-radio">
             <legend>serif</legend>
-            <label><input value="serif" name="font-family" type="radio" checked> serif</label>
-            <label><input value="sans-serif" name="font-family" type="radio"> sans-serif</label>
+            <label>serif<input value="serif" name="font-family" type="radio" checked>s</label>
+            <label>sans-serif<input value="sans-serif" name="font-family" type="radio"></label>
         </fieldset>
         <span hidden id="nb-def-cell">cell</span>
     </fieldset>
@@ -87,7 +87,7 @@
     document.querySelectorAll(`[name="color-scheme"]`).forEach(
         (x) => { x.addEventListener("change", toggleColorScheme) }
     )
-    function activityLog(msg){}
+    function activityLog(msg) { }
     function toggleRole() {
         if (event.target.checked) {
             for (const [k, selector] of Object.entries(SELECTORS)) {

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -1,5 +1,5 @@
 <dialog id="nb-settings">
-    <h1>Settings</h1>
+    <h1 role="presentation">Settings</h1>
     <form method="dialog">
         <button type="submit">Close</button>
     </form>
@@ -23,13 +23,13 @@
         <legend>font settings</legend>
         <label aria-hidden="true" for="nb-table-font-size-group">font size</label>
         <select name="font-size" id="nb-table-font-size-group">
-            <option value="xx-small">xx-small</label>
-            <option value="x-small">x-small</label>
-            <option value="small">small</label>
-            <option value="medium" selected>medium</label>
-            <option value="large">large</label>
-            <option value="x-large">x-large</label>
-            <option value="xx-large">xx-large</label>
+            <option value="xx-small">xx-small</option>
+            <option value="x-small">x-small</option>
+            <option value="small">small</option>
+            <option value="medium" selected>medium</option>
+            <option value="large">large</option>
+            <option value="x-large">x-large</option>
+            <option value="xx-large">xx-large</option>
         </select>
         <style id="nb-font-size-style"></style>
         <fieldset id="nb-font-serif-radio">
@@ -81,9 +81,10 @@
         document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none");
         document.querySelector(`head > meta[name="color-scheme"]`).setAttribute("content", event.target.value);
     }
-    document.querySelectorAll("#nb-color-scheme-radio>label>input").forEach(
+    document.querySelectorAll(`[name="color-scheme"]`).forEach(
         (x) => { x.addEventListener("change", toggleColorScheme) }
     )
+
     function toggleRole() {
         if (event.target.checked) {
             for (const [k, selector] of Object.entries(SELECTORS)) {
@@ -93,16 +94,15 @@
             }
         }
     }
-    document.querySelectorAll("#nb-table-role-radio>label>input").forEach(
+    document.querySelectorAll(`[name="table-role"]`).forEach(
         (x) => { x.addEventListener("change", toggleRole) }
     )
     function changeFont() {
         document.getElementById("nb-font-size-style").textContent = `:root {--nb-font-size: ${event.target.value};}`
     }
-    document.querySelectorAll(`select[name="font-size"]`).forEach(
+    document.querySelectorAll(`[name="font-size"]`).forEach(
         (x) => { x.addEventListener("change", changeFont) }
     )
-
     function changeFontFamily() {
         document.getElementById("nb-font-size-style").textContent = `:root {font-family: ${event.target.value};}`
     }

--- a/nbconvert_html5/templates/semantic-forms/settings.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/settings.html.j2
@@ -5,13 +5,13 @@
     </form>
     <fieldset id="nb-color-scheme-radio">
         <legend>color scheme</legend>
-        <label aria-hidden="true" for="nb-color-theme-radio">color scheme</label>
+        <span aria-hidden="true">color scheme</span>
         <label><input value="light" name="color-scheme" type="radio" checked>light mode</label>
         <label><input value="dark" name="color-scheme" type="radio">dark mode</label>
     </fieldset>
     <fieldset id="nb-table-role-radio">
         <legend>cell navigation</legend>
-        <label aria-hidden="true" for="nb-table-role-radio">cell navigation</label>
+        <span aria-hidden="true">cell navigation</span>
         <label><input value="list" name="table-role" type="radio" checked>list</label>
         <label><input value="table" name="table-role" type="radio">table</label>
         <label><input value="region" name="table-role" type="radio">landmark</label>
@@ -79,9 +79,9 @@
     };
 
     function toggleColorScheme() {
-        document.getElementById(`nb-${event.target.value}-theme`).setAttribute("media", "all");
+        document.getElementById(`nb-${event.target.value}-theme`).removeAttribute("disabled");
         let opposite = event.target.value == "dark" ? "light" : "dark"
-        document.getElementById(`nb-${opposite}-theme`).setAttribute("media", "none");
+        document.getElementById(`nb-${opposite}-theme`).setAttribute("disabled", null);
         document.querySelector(`head > meta[name="color-scheme"]`).setAttribute("content", event.target.value);
     }
     document.querySelectorAll(`[name="color-scheme"]`).forEach(
@@ -98,7 +98,8 @@
                             x.setAttribute("role", ROLES[event.target.value][k])
                         }
                     }
-                )
+                );
+                k == `table` ? log(`navigate cells as a ${event.target.value}`) : null;
             }
         }
     }

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -38,6 +38,8 @@ body {
 main,
 main>fieldset[name=cells]>table,
 main>fieldset[name=cells]>table>tbody,
+main>fieldset[name=cells] ul section.cell,
+main>fieldset[name=cells] section.cell,
 [role=toolbar]>ul {
     display: flex;
     flex-direction: column;
@@ -45,12 +47,12 @@ main>fieldset[name=cells]>table>tbody,
 }
 
 /* hide cell components when execution is disabled. */
-fieldset[name="cells"]:disabled table#cells .nb-cell_type,
-fieldset[name="cells"]:disabled table#cells .nb-metadata,
-fieldset[name="cells"]:disabled table#cells .nb-toolbar,
-fieldset[name="cells"]:disabled table#cells .nb-execution_count,
-fieldset[name="cells"]:disabled table#cells .nb-toolbar,
-fieldset[name="cells"]:disabled table#cells textarea[name=source],
+fieldset[name="cells"]:disabled #cells .nb-cell_type,
+fieldset[name="cells"]:disabled #cells .nb-metadata,
+fieldset[name="cells"]:disabled #cells .nb-toolbar,
+fieldset[name="cells"]:disabled #cells .nb-execution_count,
+fieldset[name="cells"]:disabled #cells .nb-toolbar,
+fieldset[name="cells"]:disabled #cells textarea[name=source],
 fieldset[name=cells]:disabled .cell[data-outputs="0"][data-loc="0"],
 fieldset[name=cells]:disabled .cell[data-outputs="0"] fieldset[name=outputs] {
     display: none;
@@ -82,7 +84,7 @@ table#cells>tfoot th:empty {
     visibility: collapse;
 }
 
-table#cells tr.cell {
+#cells .cell {
     display: flex;
     width: var(--nb-calc-cell-width);
     flex-direction: column;
@@ -92,14 +94,14 @@ table#cells tr.cell {
 /* layout for the cells using a grid display. */
 table#cells>thead,
 table#cells>tfoot,
-table#cells .cell.markdown .nb-metadata,
-table#cells .cell.markdown .nb-toolbar,
-table#cells .cell.markdown .nb-cell_type,
-table#cells .cell.markdown .nb-source,
-table#cells .cell.markdown .nb-index,
-table#cells .cell.markdown .nb-execution_count,
-table#cells .cell.markdown .nb-outputs>fieldset>legend,
-table#cells .cell.markdown .nb-outputs>fieldset>legend+label {
+#cells .cell.markdown .nb-metadata,
+#cells .cell.markdown .nb-toolbar,
+#cells .cell.markdown .nb-cell_type,
+#cells .cell.markdown .nb-source,
+#cells .cell.markdown .nb-index,
+#cells .cell.markdown .nb-execution_count,
+#cells .cell.markdown .nb-outputs>fieldset>legend,
+#cells .cell.markdown .nb-outputs>fieldset>legend+label {
     display: none;
 }
 
@@ -136,6 +138,14 @@ fieldset {
     margin-right: var(--nb-fieldset-margin);
     padding-left: var(--nb-fieldset-padding);
     padding-right: var(--nb-fieldset-padding);
+}
+
+fieldset#notebook {
+    border: none;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 fieldset[name=outputs] {

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -5,6 +5,8 @@
     --nb-focus-width: 3px;
     --nb-accent-color: auto;
     --nb-line-height: 1.75;
+    --nb-background-color-dark: #2b2a33;
+    --nb-background-color-light: #FFFFFF;
 
     /* default browser values */
     --nb-ul-margin-top: 1em;
@@ -117,6 +119,7 @@ table#cells .cell.markdown .nb-outputs>fieldset>legend+label {
     display: none;
 }
 
+header:focus-within,
 .cell:focus-within,
 :focus-visible {
     outline: max(var(--nb-focus-width), 1px) solid;
@@ -169,10 +172,23 @@ legend:not(:focus):not(:active) {
 }
 
 header#skip-link {
+    position: fixed;
+    transform: translateY(-100%);
     display: inline-flex;
     justify-content: space-evenly;
     align-items: center;
     width: 100vw;
+    background-color: inherit;
+}
+
+header#skip-link:focus-within {
+    transform: translateY(0);
+}
+
+header#skip-link::after {
+    content: "";
+    clear: both;
+    display: table;
 }
 
 header#skip-link>ul {
@@ -186,6 +202,16 @@ header#skip-link>ul>li {
     list-style: none;
 }
 
+header#skip-link>ul>li>kbd {
+    opacity: 0;
+    margin: calc(2*var(--nb-focus-width));
+    font-size: calc(2*var(--nb-font-size));
+    font-weight: bold;
+}
+
+header#skip-link>ul>li:focus-within>kbd {
+    opacity: 1;
+}
 
 header#skip-link:focus-within {
     transform: translateY(0);

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -7,6 +7,7 @@
     --nb-line-height: 1.75;
 
     /* default browser values */
+    --nb-ul-margin-top: 1em;
     --nb-font-size: medium;
     --nb-fieldset-margin: 2px;
     --nb-fieldset-margin-top: .35em;
@@ -33,7 +34,8 @@ body {
 
 main,
 main>fieldset[name=cells]>table,
-main>fieldset[name=cells]>table>tbody {
+main>fieldset[name=cells]>table>tbody,
+[role=toolbar]>ul {
     display: flex;
     flex-direction: column;
     align-content: stretch;
@@ -94,28 +96,6 @@ table#cells tr.cell {
 table#cells .cell.code {
     grid-template-areas: "nb-index nb-source" ". nb-source" ". nb-outputs";
     grid-template-columns: 2rem calc(var(--nb-calc-cell-width) - 2rem);
-}
-
-/* small devices */
-@media (max-width: 576px) {
-    :root {
-        --nb-fieldset-margin: 0px;
-        --nb-fieldset-padding: 0em;
-    }
-
-    table#cells .cell.code {
-        grid-template-areas: "nb-index" "nb-source" "nb-outputs";
-        grid-template-columns: var(--nb-calc-cell-width);
-    }
-
-}
-
-/* medium devices */
-@media (max-width: 768px) {
-    :root {
-        --nb-table-border: 0px;
-        --nb-body-margin: 0px;
-    }
 }
 
 table#cells tr.cell.markdown {
@@ -188,6 +168,29 @@ legend:not(:focus):not(:active) {
     white-space: nowrap;
 }
 
+header#skip-link {
+    display: inline-flex;
+    justify-content: space-evenly;
+    align-items: center;
+    width: 100vw;
+}
+
+header#skip-link>ul {
+    display: inline-flex;
+    justify-content: inherit;
+    align-items: inherit;
+    flex: 3;
+}
+
+header#skip-link>ul>li {
+    list-style: none;
+}
+
+
+header#skip-link:focus-within {
+    transform: translateY(0);
+}
+
 /* grid area labels for organizing cell parts */
 .nb-index {
     grid-area: nb-index;
@@ -233,3 +236,34 @@ legend:not(:focus):not(:active) {
 
 // XX-Large devices (larger desktops, 1400px and up)
 @media (min-width: 1400px) { ... } */
+
+/* small devices */
+@media (max-width: 576px) {
+    :root {
+        --nb-fieldset-margin: 0px;
+        --nb-fieldset-padding: 0em;
+    }
+
+    table#cells .cell.code {
+        grid-template-areas: "nb-index" "nb-source" "nb-outputs";
+        grid-template-columns: var(--nb-calc-cell-width);
+    }
+
+    header#skip-link {
+        display: block;
+        width: 100vw;
+    }
+
+    header#skip-link>ul {
+        display: block;
+    }
+
+}
+
+/* medium devices */
+@media (max-width: 768px) {
+    :root {
+        --nb-table-border: 0px;
+        --nb-body-margin: 0px;
+    }
+}

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -44,10 +44,6 @@ main>fieldset[name=cells]>table>tbody,
     align-content: stretch;
 }
 
-fieldset[name=cells] {
-    width: var(--nb-calc-fieldset-width);
-}
-
 /* hide cell components when execution is disabled. */
 fieldset[name="cells"]:disabled table#cells .nb-cell_type,
 fieldset[name="cells"]:disabled table#cells .nb-metadata,
@@ -74,10 +70,6 @@ textarea[name=source] {
 }
 
 
-table#cells {
-    width: var(--nb-calc-table-width);
-}
-
 table#cells,
 table#cells .cell>td,
 table#cells .cell>th {
@@ -91,24 +83,15 @@ table#cells>tfoot th:empty {
 }
 
 table#cells tr.cell {
-    display: grid;
+    display: flex;
     width: var(--nb-calc-cell-width);
-    box-sizing: border-box;
+    flex-direction: column;
 }
 
-table#cells .cell.code {
-    grid-template-areas: "nb-index nb-source" ". nb-source" ". nb-outputs";
-    grid-template-columns: 2rem calc(var(--nb-calc-cell-width) - 2rem);
-}
-
-table#cells tr.cell.markdown {
-    grid-template-areas: "nb-outputs";
-    grid-template-columns: var(--nb-calc-cell-width);
-}
 
 /* layout for the cells using a grid display. */
-table#cells:not([role=table])>thead,
-table#cells:not([role=table])>tfoot,
+table#cells>thead,
+table#cells>tfoot,
 table#cells .cell.markdown .nb-metadata,
 table#cells .cell.markdown .nb-toolbar,
 table#cells .cell.markdown .nb-cell_type,
@@ -184,74 +167,6 @@ legend:not(:focus):not(:active) {
 
 #skip-link:focus-within {
     transform: translateY(0);
-}
-
-/* grid area labels for organizing cell parts */
-.nb-index {
-    grid-area: nb-index;
-    padding-top: var(--nb-calc-fieldset-top);
-}
-
-.nb-cell_type {
-    grid-area: nb-cell_type;
-}
-
-
-.nb-execution_count {
-    grid-area: nb-execution_count;
-}
-
-.nb-source {
-    grid-area: nb-source;
-}
-
-.nb-outputs {
-    grid-area: nb-outputs;
-}
-
-.nb-metadata {
-    grid-area: nb-metadata;
-}
-
-.nb-toolbar {
-    grid-area: nb-toolbar;
-}
-
-/* 
-
-
-// Medium devices (tablets, 768px and up)
-@media (min-width: 768px) { ... }
-
-// Large devices (desktops, 992px and up)
-@media (min-width: 992px) { ... }
-
-// X-Large devices (large desktops, 1200px and up)
-@media (min-width: 1200px) { ... }
-
-// XX-Large devices (larger desktops, 1400px and up)
-@media (min-width: 1400px) { ... } */
-
-/* small devices */
-@media (max-width: 576px) {
-    :root {
-        --nb-fieldset-margin: 0px;
-        --nb-fieldset-padding: 0em;
-    }
-
-    table#cells .cell.code {
-        grid-template-areas: "nb-index" "nb-source" "nb-outputs";
-        grid-template-columns: var(--nb-calc-cell-width);
-    }
-
-}
-
-/* medium devices */
-@media (max-width: 768px) {
-    :root {
-        --nb-table-border: 0px;
-        --nb-body-margin: 0px;
-    }
 }
 
 a[href="#notebook"] {

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -35,15 +35,22 @@ body {
     line-height: var(--nb-line-height);
 }
 
-main,
-main>fieldset[name=cells]>table,
-main>fieldset[name=cells]>table>tbody,
-main>fieldset[name=cells] ul section.cell,
-main>fieldset[name=cells] section.cell,
+table#cells,
+table#cells .cell>td {
+    display: block;
+}
+
+table#cells>tbody,
 [role=toolbar]>ul {
     display: flex;
     flex-direction: column;
     align-content: stretch;
+}
+
+table#cells .cell {
+    display: flex;
+    width: var(--nb-calc-cell-width);
+    flex-direction: column;
 }
 
 /* hide cell components when execution is disabled. */
@@ -72,29 +79,17 @@ textarea[name=source] {
 }
 
 
-table#cells,
-table#cells .cell>td,
-table#cells .cell>th {
-    display: block;
-}
-
-
-table#cells>tfoot td:empty,
-table#cells>tfoot th:empty {
+table#cells+table td:empty,
+table#cells+table th:empty {
     visibility: collapse;
 }
 
-#cells .cell {
-    display: flex;
-    width: var(--nb-calc-cell-width);
-    flex-direction: column;
-}
 
 
 /* layout for the cells using a grid display. */
-table#cells>thead,
-table#cells>tfoot,
-table#cells>tbody>tr.cell>th:first-child,
+form#nb-visibility > table,
+table#cells+table,
+table#cells>tr.cell>th:first-child,
 #cells .cell .nb-loc,
 #cells .cell.markdown .nb-metadata,
 #cells .cell.markdown .nb-toolbar,

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -174,3 +174,20 @@ a[href="#notebook"] {
     float: right;
     bottom: 0;
 }
+
+
+/* small devices */
+@media (max-width: 576px) {
+    :root {
+        --nb-fieldset-margin: 0px;
+        --nb-fieldset-padding: 0em;
+    }
+}
+
+/* medium devices */
+@media (max-width: 768px) {
+    :root {
+        --nb-table-border: 0px;
+        --nb-body-margin: 0px;
+    }
+}

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -2,20 +2,23 @@
 
 /* style variables */
 :root {
-    --cell-padding: .5em;
-    --focus-width: 3px;
+    --nb-focus-width: 3px;
+    --nb-accent-color: auto;
+    --nb-line-height: 1.75;
 
     /* default browser values */
-    --font-size: medium;
+    --nb-font-size: medium;
     --nb-fieldset-margin: 2px;
-    --nb-fieldset-padding-horizontal: .75em;
+    --nb-fieldset-margin-top: .35em;
+    --nb-fieldset-padding: .75em;
     --nb-fieldset-border: 2px;
-
     --nb-body-margin: 8px;
     --nb-table-border: 2px;
-    --nb-calc-fieldset-edge: var(--nb-fieldset-margin) + var(--nb-fieldset-padding-horizontal) + var(--nb-fieldset-border);
+    --nb-calc-fieldset-edge: var(--nb-fieldset-margin) + var(--nb-fieldset-padding) + var(--nb-fieldset-border);
+    --nb-calc-fieldset-top: calc(var(--nb-fieldset-border) + var(--nb-fieldset-margin-top));
     --nb-calc-cell-margin: calc(var(--nb-calc-fieldset-edge) + var(--nb-body-margin) + var(--nb-table-border));
     --nb-calc-cell-width: calc(100vw - 2 * var(--nb-calc-cell-margin));
+    --nb-calc-table-width: calc(100vw - 2 * var(--nb-calc-cell-margin) - 2 * var(--nb-table-border));
     --nb-calc-cell-fieldset-width: calc(var(--nb-calc-cell-width) - 2 * var(--nb-calc-fieldset-edge));
     /* --nb-calc-cell-margin: calc((100vw - var(--nb-calc-cell-width))/2 - var(--nb-fieldset-border) - var(--nb-table-border)) */
 }
@@ -23,16 +26,9 @@
 body {
     overflow-x: hidden;
     margin: var(--nb-body-margin);
-}
-
-fieldset {
-    margin-left: var(--nb-fieldset-margin);
-    margin-right: var(--nb-fieldset-margin);
-    border: var(--nb-fieldset-border) groove;
-}
-
-textarea[name=source] {
-    width: 100%;
+    font-size: var(--nb-font-size);
+    accent-color: var(--nb-accent-color);
+    line-height: var(--nb-line-height);
 }
 
 main,
@@ -47,164 +43,104 @@ fieldset[name=cells] {
     width: var(--nb-calc-fieldset-width);
 }
 
-.cell:focus-within,
-:focus-visible {
-    outline: var(--focus-width) solid;
-    box-shadow: 0 0 0 calc(2 * var(--focus-width));
+/* hide cell components when execution is disabled. */
+fieldset[name="cells"]:disabled table#cells .nb-cell_type,
+fieldset[name="cells"]:disabled table#cells .nb-metadata,
+fieldset[name="cells"]:disabled table#cells .nb-toolbar,
+fieldset[name="cells"]:disabled table#cells .nb-execution_count,
+fieldset[name="cells"]:disabled table#cells .nb-toolbar,
+fieldset[name="cells"]:disabled table#cells textarea[name=source],
+fieldset[name=cells]:disabled .cell[data-outputs="0"][data-loc="0"],
+fieldset[name=cells]:disabled .cell[data-outputs="0"] fieldset[name=outputs] {
+    display: none;
 }
 
-fieldset[name=cells]>table {
-    display: block;
-}
-
-fieldset[name=cells]:disabled {
-
-    /* the standard disabled styles have inaccessible color contrast. */
-    textarea {
-        color: unset;
-    }
-
-    /* hide cell toolbars */
-    td.toolbar,
-    form[name="/cells/"] {
-        display: none;
-    }
-
-    /* hide empty cells */
-    .cell[data-outputs="0"] {
-
-        &[data-loc="0"],
-        fieldset[name=outputs] {
-            display: none;
-        }
-    }
-
-}
 
 /* the input and output become interactive when there is overflow.*/
 textarea[name=source],
+fieldset[name=input],
 [name=outputs] {
     overflow: auto;
     min-width: 0;
 }
 
-/* hide the display group when there are no outputs */
-.cell[data-outputs="0"]>[name="outputs"] {
-    display: none;
+textarea[name=source] {
+    width: 100%;
 }
 
-table:not([role=table])>thead {
-    display: none;
+
+table#cells {
+    width: var(--nb-calc-table-width);
 }
 
-table#cells tfoot {
-    display: none;
+table#cells,
+table#cells .cell>td,
+table#cells .cell>th {
+    display: block;
+}
 
-    td:empty,
-    th:empty {
-        visibility: collapse;
-    }
+
+table#cells>tfoot td:empty,
+table#cells>tfoot th:empty {
+    visibility: collapse;
 }
 
 table#cells tr.cell {
     display: grid;
     width: var(--nb-calc-cell-width);
     box-sizing: border-box;
-    margin-left: var(--nb-calc-cell-margin);
-    margin-right: var(--nb-calc-cell-margin);
-    margin-top: var(--focus-width);
-    margin-bottom: var(--focus-width);
+}
 
-    &.code {
-        grid-template-areas: "index input" ". input" ". outputs";
-        grid-template-columns: 4rem calc(var(--nb-calc-cell-width) - 4rem);
+table#cells .cell.code {
+    grid-template-areas: "nb-index nb-source" ". nb-source" ". nb-outputs";
+    grid-template-columns: 2rem calc(var(--nb-calc-cell-width) - 2rem);
+}
+
+/* small devices */
+@media (max-width: 576px) {
+    :root {
+        --nb-fieldset-margin: 0px;
+        --nb-fieldset-padding: 0em;
     }
 
-    &.markdown {
-        grid-template-areas: "outputs";
+    table#cells .cell.code {
+        grid-template-areas: "nb-index" "nb-source" "nb-outputs";
         grid-template-columns: var(--nb-calc-cell-width);
     }
 
 }
 
-/* layout for the cells using a grid display. */
-.cell {
-
-    /* layout for cells. */
-    &.markdown {
-
-        >[name=metadata],
-        >td.metadata,
-        >td.cell_type,
-        >td.source,
-        >[name=input],
-        >th.anchor>a,
-        >a,
-        >td.execution_count,
-        >[name=execution_count],
-        [name=cell_type]+span,
-        [name=outputs]>legend {
-            display: none;
-        }
-
-        [name=outputs] {
-            border: unset;
-        }
-    }
-
-    >td {
-        display: block;
-    }
-
-    >a {
-        grid-area: index;
-    }
-
-    >td.cell_type,
-    >[name=cell_type] {
-        grid-area: cell_type;
-        display: none;
-
-        +span {
-            display: none;
-        }
-    }
-
-    >td.source,
-    >[name=input] {
-        grid-area: input;
-
-        legend+label {
-            display: none;
-        }
-    }
-
-    >td.output,
-    >[name=outputs] {
-        grid-area: outputs;
-    }
-
-    >td.metadata,
-    >[name=metadata] {
-        grid-area: metadata;
-        display: none;
-    }
-
-    >td.execution_count,
-    >[name=execution_count] {
-        grid-area: execution_count;
-        display: none;
-    }
-
-    >td.toolbar,
-    >form {
-        grid-area: form;
+/* medium devices */
+@media (max-width: 768px) {
+    :root {
+        --nb-table-border: 0px;
+        --nb-body-margin: 0px;
     }
 }
 
+table#cells tr.cell.markdown {
+    grid-template-areas: "nb-outputs";
+    grid-template-columns: var(--nb-calc-cell-width);
+}
 
-[name=cells]>ol>li {
-    list-style: none;
+/* layout for the cells using a grid display. */
+table#cells:not([role=table])>thead,
+table#cells:not([role=table])>tfoot,
+table#cells .cell.markdown .nb-metadata,
+table#cells .cell.markdown .nb-toolbar,
+table#cells .cell.markdown .nb-cell_type,
+table#cells .cell.markdown .nb-source,
+table#cells .cell.markdown .nb-index,
+table#cells .cell.markdown .nb-execution_count,
+table#cells .cell.markdown .nb-outputs>fieldset>legend,
+table#cells .cell.markdown .nb-outputs>fieldset>legend+label {
+    display: none;
+}
+
+.cell:focus-within,
+:focus-visible {
+    outline: max(var(--nb-focus-width), 1px) solid;
+    box-shadow: 0 0 0 calc(2 * max(var(--nb-focus-width), 1px));
 }
 
 .visually-hidden:not(:focus-within):not(:active) {
@@ -217,11 +153,83 @@ table#cells tr.cell {
     width: 1px;
 }
 
-.full-width {
-    width: 100vw;
-    position: relative;
-    left: 50%;
-    right: 50%;
-    margin-left: -50vw;
-    margin-right: -50vw;
+/* default tag settings. */
+textarea {
+    line-height: var(--nb-line-height);
+    overflow: auto;
 }
+
+textarea:disabled {
+    color: unset;
+}
+
+fieldset {
+    border: var(--nb-fieldset-border) groove;
+    margin-left: var(--nb-fieldset-margin);
+    margin-right: var(--nb-fieldset-margin);
+    padding-left: var(--nb-fieldset-padding);
+    padding-right: var(--nb-fieldset-padding);
+}
+
+fieldset[name=outputs] {
+    border: unset;
+}
+
+
+/* hide legends and use labels instead. they increase the hit area.
+https://adrianroselli.com/2022/07/use-legend-and-fieldset.html */
+legend:not(:focus):not(:active) {
+    position: absolute;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    width: 1px;
+    height: 1px;
+    white-space: nowrap;
+}
+
+/* grid area labels for organizing cell parts */
+.nb-index {
+    grid-area: nb-index;
+    padding-top: var(--nb-calc-fieldset-top);
+}
+
+.nb-cell_type {
+    grid-area: nb-cell_type;
+}
+
+
+.nb-execution_count {
+    grid-area: nb-execution_count;
+}
+
+.nb-source {
+    grid-area: nb-source;
+}
+
+.nb-outputs {
+    grid-area: nb-outputs;
+}
+
+.nb-metadata {
+    grid-area: nb-metadata;
+}
+
+.nb-toolbar {
+    grid-area: nb-toolbar;
+}
+
+/* 
+
+
+// Medium devices (tablets, 768px and up)
+@media (min-width: 768px) { ... }
+
+// Large devices (desktops, 992px and up)
+@media (min-width: 992px) { ... }
+
+// X-Large devices (large desktops, 1200px and up)
+@media (min-width: 1200px) { ... }
+
+// XX-Large devices (larger desktops, 1400px and up)
+@media (min-width: 1400px) { ... } */

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -1,0 +1,138 @@
+/* style for the accessible themes */
+
+/* style variables */
+:root {
+    --cell-padding: .5em;
+    --focus-width: .2em;
+}
+
+/* the main and textareas occupy the entire width. */
+main,
+textarea[name="source"] {
+    width: 100%;
+}
+
+main>form {
+    display: none;
+}
+
+/* the input and output become interactive when there is overflow.*/
+textarea[name=source],
+[name=outputs] {
+    overflow: auto;
+    min-width: 0;
+}
+
+/* the standard disabled styles have inaccessible color contrast. */
+fieldset[name=input]:disabled>textarea {
+    color: unset;
+}
+
+/* hide the display group when there are no outputs */
+section[data-outputs="0"]>[name="outputs"] {
+    display: none;
+}
+
+
+/* layout for the cells using a grid display. */
+tr.cell,
+section.cell {
+    display: grid;
+
+    /* style the markdown cell to only show the output area */
+    &.markdown {
+        grid-template-areas: "outputs";
+        grid-template-columns: auto;
+
+        td.source,
+        >[name=input],
+        td.anchor>a,
+        td.execution_count,
+        >[name=execution_count],
+        td.metadata,
+        >[name=metadata],
+        td.cell_type,
+        [name=cell_type]+span,
+        [name=outputs]>legend {
+            display: none;
+        }
+
+        fieldset[name=outputs] {
+            border: none;
+        }
+    }
+
+    /* layout for code cells. */
+    &.code {
+        grid-template-areas: "index input" ". input" ". outputs";
+        grid-template-columns: 2rem auto;
+
+        &[data-outputs="0"] fieldset[name=outputs] {
+            display: none;
+        }
+    }
+
+    >a {
+        grid-area: index;
+    }
+
+    >td.cell_type,
+    >[name=cell_type] {
+        grid-area: cell_type;
+        display: none;
+
+        +span {
+            display: none;
+        }
+    }
+
+    >td.source,
+    >[name=input] {
+        grid-area: input;
+
+        legend+label {
+            display: none;
+        }
+    }
+
+    >td.output,
+    >[name=outputs] {
+        grid-area: outputs;
+    }
+
+    >td.metadata,
+    >[name=metadata] {
+        grid-area: metadata;
+        display: none;
+    }
+
+    >td.execution_count,
+    >[name=execution_count] {
+        grid-area: execution_count;
+        display: none;
+    }
+
+    >td.toolbar,
+    >form {
+        grid-area: form;
+        display: none;
+    }
+}
+
+main>table[role=document]>thead {
+    display: none;
+}
+
+main>ol>li {
+    list-style: none;
+}
+
+.visually-hidden:not(:focus):not(:active) {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -4,16 +4,42 @@
 :root {
     --cell-padding: .5em;
     --focus-width: .2em;
+    --font-size: medium;
 }
 
 /* the main and textareas occupy the entire width. */
-main,
 textarea[name="source"] {
     width: 100%;
 }
 
-main>form {
-    display: none;
+fieldset[name=cells]>table {
+    display: block;
+    /* width: 100%; */
+}
+
+fieldset[name=cells]:disabled {
+    width: 100%;
+
+    /* the standard disabled styles have inaccessible color contrast. */
+    textarea {
+        color: unset;
+    }
+
+    /* hide cell toolbars */
+    td.toolbar,
+    form[name="/cells/"] {
+        display: none;
+    }
+
+    /* hide empty cells */
+    .cell[data-outputs="0"] {
+
+        &[data-loc="0"],
+        fieldset[name=outputs] {
+            display: none;
+        }
+    }
+
 }
 
 /* the input and output become interactive when there is overflow.*/
@@ -23,54 +49,65 @@ textarea[name=source],
     min-width: 0;
 }
 
-/* the standard disabled styles have inaccessible color contrast. */
-fieldset[name=input]:disabled>textarea {
-    color: unset;
-}
-
 /* hide the display group when there are no outputs */
-section[data-outputs="0"]>[name="outputs"] {
+.cell[data-outputs="0"]>[name="outputs"] {
     display: none;
 }
 
+table:not([role=table])>thead {
+    display: none;
+}
+table#cells > tbody {
+    display: block;
+}
+
+table#cells tfoot {
+    display: none;
+
+    td:empty,
+    th:empty {
+        visibility: collapse;
+    }
+}
 
 /* layout for the cells using a grid display. */
-tr.cell,
-section.cell {
+.cell {
     display: grid;
 
-    /* style the markdown cell to only show the output area */
+    /* layout for cells. */
+    &.code {
+        grid-template-areas: "index input" ". input" ". outputs";
+        grid-template-columns: 2rem auto;
+    }
+
     &.markdown {
         grid-template-areas: "outputs";
         grid-template-columns: auto;
+    }
 
-        td.source,
-        >[name=input],
-        td.anchor>a,
-        >a,
-        td.execution_count,
-        >[name=execution_count],
-        td.metadata,
+    &.markdown {
+
         >[name=metadata],
-        td.cell_type,
+        >td.metadata,
+        >td.cell_type,
+        >td.source,
+        >[name=input],
+        >th.anchor>a,
+        >a,
+        >td.execution_count,
+        >[name=execution_count],
         [name=cell_type]+span,
         [name=outputs]>legend {
             display: none;
         }
 
-        fieldset[name=outputs] {
-            border: none;
+        [name=outputs] {
+            border: unset;
         }
     }
 
-    /* layout for code cells. */
-    &.code {
-        grid-template-areas: "index input" ". input" ". outputs";
-        grid-template-columns: 2rem auto;
-
-        &[data-outputs="0"] fieldset[name=outputs] {
-            display: none;
-        }
+    >td {
+        display: block;
     }
 
     >a {
@@ -116,19 +153,15 @@ section.cell {
     >td.toolbar,
     >form {
         grid-area: form;
-        display: none;
     }
 }
 
-main>table[role=document]>thead {
-    display: none;
-}
 
-main>ol>li {
+[name=cells]>ol>li {
     list-style: none;
 }
 
-.visually-hidden:not(:focus):not(:active) {
+.visually-hidden:not(:focus-within):not(:active) {
     clip: rect(0 0 0 0);
     clip-path: inset(50%);
     height: 1px;
@@ -136,4 +169,13 @@ main>ol>li {
     position: absolute;
     white-space: nowrap;
     width: 1px;
+}
+
+.full-width {
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
 }

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -94,11 +94,13 @@ table#cells>tfoot th:empty {
 /* layout for the cells using a grid display. */
 table#cells>thead,
 table#cells>tfoot,
+table#cells>tbody>tr.cell>th:first-child,
+#cells .cell .nb-loc,
 #cells .cell.markdown .nb-metadata,
 #cells .cell.markdown .nb-toolbar,
 #cells .cell.markdown .nb-cell_type,
 #cells .cell.markdown .nb-source,
-#cells .cell.markdown .nb-index,
+/* #cells .cell.markdown .nb-index, */
 #cells .cell.markdown .nb-execution_count,
 #cells .cell.markdown .nb-outputs>fieldset>legend,
 #cells .cell.markdown .nb-outputs>fieldset>legend+label {

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -3,22 +3,61 @@
 /* style variables */
 :root {
     --cell-padding: .5em;
-    --focus-width: .2em;
+    --focus-width: 3px;
+
+    /* default browser values */
     --font-size: medium;
+    --nb-fieldset-margin: 2px;
+    --nb-fieldset-padding-horizontal: .75em;
+    --nb-fieldset-border: 2px;
+
+    --nb-body-margin: 8px;
+    --nb-table-border: 2px;
+    --nb-calc-fieldset-edge: var(--nb-fieldset-margin) + var(--nb-fieldset-padding-horizontal) + var(--nb-fieldset-border);
+    --nb-calc-cell-margin: calc(var(--nb-calc-fieldset-edge) + var(--nb-body-margin) + var(--nb-table-border));
+    --nb-calc-cell-width: calc(100vw - 2 * var(--nb-calc-cell-margin));
+    --nb-calc-cell-fieldset-width: calc(var(--nb-calc-cell-width) - 2 * var(--nb-calc-fieldset-edge));
+    /* --nb-calc-cell-margin: calc((100vw - var(--nb-calc-cell-width))/2 - var(--nb-fieldset-border) - var(--nb-table-border)) */
 }
 
-/* the main and textareas occupy the entire width. */
-textarea[name="source"] {
+body {
+    overflow-x: hidden;
+    margin: var(--nb-body-margin);
+}
+
+fieldset {
+    margin-left: var(--nb-fieldset-margin);
+    margin-right: var(--nb-fieldset-margin);
+    border: var(--nb-fieldset-border) groove;
+}
+
+textarea[name=source] {
     width: 100%;
+}
+
+main,
+main>fieldset[name=cells]>table,
+main>fieldset[name=cells]>table>tbody {
+    display: flex;
+    flex-direction: column;
+    align-content: stretch;
+}
+
+fieldset[name=cells] {
+    width: var(--nb-calc-fieldset-width);
+}
+
+.cell:focus-within,
+:focus-visible {
+    outline: var(--focus-width) solid;
+    box-shadow: 0 0 0 calc(2 * var(--focus-width));
 }
 
 fieldset[name=cells]>table {
     display: block;
-    /* width: 100%; */
 }
 
 fieldset[name=cells]:disabled {
-    width: 100%;
 
     /* the standard disabled styles have inaccessible color contrast. */
     textarea {
@@ -57,9 +96,6 @@ textarea[name=source],
 table:not([role=table])>thead {
     display: none;
 }
-table#cells > tbody {
-    display: block;
-}
 
 table#cells tfoot {
     display: none;
@@ -70,21 +106,31 @@ table#cells tfoot {
     }
 }
 
-/* layout for the cells using a grid display. */
-.cell {
+table#cells tr.cell {
     display: grid;
+    width: var(--nb-calc-cell-width);
+    box-sizing: border-box;
+    margin-left: var(--nb-calc-cell-margin);
+    margin-right: var(--nb-calc-cell-margin);
+    margin-top: var(--focus-width);
+    margin-bottom: var(--focus-width);
 
-    /* layout for cells. */
     &.code {
         grid-template-areas: "index input" ". input" ". outputs";
-        grid-template-columns: 2rem auto;
+        grid-template-columns: 4rem calc(var(--nb-calc-cell-width) - 4rem);
     }
 
     &.markdown {
         grid-template-areas: "outputs";
-        grid-template-columns: auto;
+        grid-template-columns: var(--nb-calc-cell-width);
     }
 
+}
+
+/* layout for the cells using a grid display. */
+.cell {
+
+    /* layout for cells. */
     &.markdown {
 
         >[name=metadata],

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -47,6 +47,7 @@ section.cell {
         td.source,
         >[name=input],
         td.anchor>a,
+        >a,
         td.execution_count,
         >[name=execution_count],
         td.metadata,

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -23,6 +23,7 @@
     --nb-calc-cell-width: calc(100vw - 2 * var(--nb-calc-cell-margin));
     --nb-calc-table-width: calc(100vw - 2 * var(--nb-calc-cell-margin) - 2 * var(--nb-table-border));
     --nb-calc-cell-fieldset-width: calc(var(--nb-calc-cell-width) - 2 * var(--nb-calc-fieldset-edge));
+    --nb-calc-header-width: calc(100vw - 2 *var(--nb-body-margin));
     /* --nb-calc-cell-margin: calc((100vw - var(--nb-calc-cell-width))/2 - var(--nb-fieldset-border) - var(--nb-table-border)) */
 }
 
@@ -171,73 +172,19 @@ legend:not(:focus):not(:active) {
     white-space: nowrap;
 }
 
-header#skip-link {
+#skip-link {
     position: fixed;
-    transform: translateY(-100%);
+    transform: translateY(-200%);
     display: inline-flex;
     justify-content: space-evenly;
     align-items: center;
-    width: 100vw;
+    width: var(--nb-calc-header-width);
     background-color: inherit;
 }
 
-header#skip-link:focus-within {
+#skip-link:focus-within {
     transform: translateY(0);
 }
-
-header#skip-link::after {
-    content: "";
-    clear: both;
-    display: table;
-}
-
-header#skip-link>ul {
-    display: inline-flex;
-    justify-content: inherit;
-    align-items: inherit;
-    flex: 3;
-}
-
-header#skip-link>ul>li {
-    list-style: none;
-}
-
-header#skip-link>ul>li {
-    margin: calc(2*var(--nb-focus-width));
-}
-
-header#skip-link>ul>li>:last-child::after,
-header#skip-link>ul>li>:first-child::before {
-    opacity: 0;
-    font-size: calc(2*var(--nb-font-size));
-    font-weight: bold;
-}
-
-header#skip-link>ul>li:focus-within>:last-child::after,
-header#skip-link>ul>li:focus-within>:first-child::before {
-    opacity: 1;
-}
-
-header#skip-link:focus-within {
-    transform: translateY(0);
-}
-
-header#skip-link>ul[aria-orientation=horizontal]>li:not(:first-child)>:first-child::before {
-    content: "‹";
-}
-
-header#skip-link>ul[aria-orientation=horizontal]>li:not(:last-child)>:last-child::after {
-    content: "›";
-}
-
-header#skip-link>ul[aria-orientation=vertical]>li:not(:first-child)>:first-child::before {
-    content: "˄";
-}
-
-header#skip-link>ul[aria-orientation=vertical]>li:not(:last-child)>:last-child::after {
-    content: "⌄";
-}
-
 
 /* grid area labels for organizing cell parts */
 .nb-index {
@@ -297,15 +244,6 @@ header#skip-link>ul[aria-orientation=vertical]>li:not(:last-child)>:last-child::
         grid-template-columns: var(--nb-calc-cell-width);
     }
 
-    header#skip-link {
-        display: block;
-        width: 100vw;
-    }
-
-    header#skip-link>ul {
-        display: block;
-    }
-
 }
 
 /* medium devices */
@@ -314,4 +252,10 @@ header#skip-link>ul[aria-orientation=vertical]>li:not(:last-child)>:last-child::
         --nb-table-border: 0px;
         --nb-body-margin: 0px;
     }
+}
+
+a[href="#notebook"] {
+    position: sticky;
+    float: right;
+    bottom: 0;
 }

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -140,7 +140,7 @@ fieldset {
     padding-right: var(--nb-fieldset-padding);
 }
 
-fieldset#notebook {
+fieldset[form="notebook"] {
     border: none;
     margin-left: 0;
     margin-right: 0;

--- a/nbconvert_html5/templates/semantic-forms/style.css
+++ b/nbconvert_html5/templates/semantic-forms/style.css
@@ -202,20 +202,42 @@ header#skip-link>ul>li {
     list-style: none;
 }
 
-header#skip-link>ul>li>kbd {
-    opacity: 0;
+header#skip-link>ul>li {
     margin: calc(2*var(--nb-focus-width));
+}
+
+header#skip-link>ul>li>:last-child::after,
+header#skip-link>ul>li>:first-child::before {
+    opacity: 0;
     font-size: calc(2*var(--nb-font-size));
     font-weight: bold;
 }
 
-header#skip-link>ul>li:focus-within>kbd {
+header#skip-link>ul>li:focus-within>:last-child::after,
+header#skip-link>ul>li:focus-within>:first-child::before {
     opacity: 1;
 }
 
 header#skip-link:focus-within {
     transform: translateY(0);
 }
+
+header#skip-link>ul[aria-orientation=horizontal]>li:not(:first-child)>:first-child::before {
+    content: "‹";
+}
+
+header#skip-link>ul[aria-orientation=horizontal]>li:not(:last-child)>:last-child::after {
+    content: "›";
+}
+
+header#skip-link>ul[aria-orientation=vertical]>li:not(:first-child)>:first-child::before {
+    content: "˄";
+}
+
+header#skip-link>ul[aria-orientation=vertical]>li:not(:last-child)>:last-child::after {
+    content: "⌄";
+}
+
 
 /* grid area labels for organizing cell parts */
 .nb-index {

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -1,113 +1,41 @@
-{%- extends 'semantic-forms/index.html.j2' -%}
-{% from 'mathjax.html.j2' import mathjax %}
-{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+{%- extends 'semantic-forms/main.html.j2' -%}
+{% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
-
-{% block body_loop %}
-<table class="notebook cells" aria-label="cells" aria-rowcount="{{len(nb.cells)}}">
-    <colgroup>
-        <col class="execution_count">
-        <col class="source">
-        <col class="outputs">
-        <col class="cell_type">
-        <col class="metadata">
-        <col class="toolbar">
-    </colgroup>
-    <thead>
-        <tr class="cell">
-            <th scope="col">execution count</th>
-            <th scope="col">source</th>
-            <th scope="col">outputs</th>
-            <th scope="col">cell type</th>
-            <th scope="col">metadata</th>
-            <th scope="col">toolbar</th>
-        </tr>
-    </thead>
-    <tbody id="/cells">
-    {{super()}}
-    </tbody>
-    <tfoot>
-        <td class="execution count"></td>
-        <td class="source"></td>
-        <td class="outputs"></td>
-        <td class="cell type"></td>
-        <td class="metadata"></td>
-        <td class="toolbar"></td>
-    </tfoot>
-</table>
-{% endblock body_loop %}
-
-
-{% block any_cell %}
-{{cell_row(cell, nb, resources)}}
-{% endblock any_cell %}
-
-{% macro highlight(body, type) %}
-{{markdown("```{{type}}\n" + json.dumps(nb.metadata, indent=2) + "\n```\n")}}
-{% endmacro %}
-
-
-{% macro cell_row(cell, nb, resources={}) %}
-{% set count = nb.cells.index(cell) %}
-{% set ID = "cell-" + str(cell.id or count) %}
-<tr class="cell {{cell.cell_type}} {{celltags(cell)}}" id="/cells/{{count}}" draggable="false" aria-busy="false"
-    aria-rowindex="{{nb.cells.index(cell)+1}}">
-    <td class="execution_count" {{hide(cell.execution_count)}}><label for="{{ID}}-source"
-            id="{{ID}}-exec">{{cell.execution_count or ""}}</label></td>
-    <td class="source" {{hide(resources.global_content_filter.include_input)}}>
-        {{source_cell(cell, nb, ID)}}</td>
-    <td class="outputs">
-        {{outputs_cell(cell, ID)}}</td>
-    <td class="cell_type">{{cell_type_cell(cell)}}</td>
-    <td class="metadata">
-        <script id="/cells/{{count}}/metadata"
-            type="application/json">{{json.dumps(cell.metadata, indent=2) | escape_html}}</script>
-    </td>
-    <td class="toolbar">{{cell_toolbar(cell, ID)}}</td>
+{% macro cell_row(cell, loop) %}
+<tr role="region" class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
+    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
+    data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
+    <td role="none" class="anchor">{{cell_anchor(loop.index)}}</td>
+    <td role="none" class="toolbar">{{cell_form(loop.index)}}</td>
+    <td role="none" class="execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
+    <td role="none" class="cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
+    <td role="none" class="source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
+    <td role="none" class="output">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
+        cell.execution_count)}}</td>
+    <td role="none" class="metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
 </tr>
 {% endmacro %}
 
+{% block body_header %}
+{{super()}}
+<table role="document">
+    <caption>Notebook</caption>
+    <thead>
+        <th class="anchor">index</th>
+        <th class="toolbar">toolbar</th>
+        <th class="execution_count">execution_count</th>
+        <th class="cell_type">cell_type</th>
+        <th class="source">source</th>
+        <th class="output">output</th>
+        <th class="metadata">metadata</th>
+    </thead>
+    <tbody>
+        {% endblock body_header %}
 
-{% macro cell_type_cell(cell) %}
-{% set cell_type = cell.cell_type %}
-<label class="cell_type">
-    <select name="cell_type" disabled>
-        <option {% if cell_type=="code" %}selected{% endif %} value="code">code</option>
-        <option {% if cell_type=="markdown" %}selected{% endif %} value="markdown">markdown</option>
-        <option {% if cell_type=="raw" %}selected{% endif %} value="raw">raw</option>
-        <option {% if cell_type=="unknown" %}selected{% endif %} value="unknown">unknown</option>
-    </select>
-</label>
-{% endmacro %}
+        {% block body_footer %}
+    </tbody>
+</table>
+{{super()}}
+{% endblock body_footer %}
 
-{% macro source_cell(cell, nb, ID) %}
-{% set count = nb["cells"].index(cell) +1%}
-{% set source = cell.source %}
-<form id="{{ID}}" aria-label="{{cell.cell_type}} cell {{count}}">
-    <textarea readonly class="visually-hidden" name="source" id="{{ID}}-source" aria-hidden="false" autocomplete="off"
-        autocorrect="off" placeholder="" spellcheck="default" rows="{{len(source.rstrip().splitlines())}}"
-        aria-labelledby="{{ID}}-exec" wrap="soft">{{source}}</textarea>
-    <output class="render" for="{{ID}}-source" aria-hidden="{% if cell.cell_type == "markdown" %}false{% else %}true{% endif
-        %}">
-        {% if cell.cell_type=="markdown" %}{{markdown(cell.source) | strip_files_prefix}}{% endif %}
-        {% if cell.cell_type=="code" %}{{ cell.source | highlight_code(metadata=cell.metadata) }}{% endif %}
-    </output>
-</form>
-{% endmacro %}
-
-{% macro outputs_cell(cell, ID) %}
-{% for i, output in enumerate(cell.outputs) %}
-{% block output scoped %}{% block output_prompt %}{% endblock %}{{super()}}{% endblock %}
-{% endfor %}
-{% endmacro %}
-
-
-{% macro cell_toolbar(cell, ID) %}
-<div role="toolbar">
-    <input class="run" type="submit" form="{{ID}}" for="{{ID}}-source" value="run" title="run the cell"
-        tabindex="0">
-    <button onclick="document.querySelector('#{{ID}}-metadata').showModal()" title="show metadata">🛈</button>
-</div>
-{% endmacro %}
-
-{% macro hide(x) %}{% if not x %}hidden{% endif %}{% endmacro %}
+{% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -7,7 +7,7 @@
     <legend aria-hidden="true" id="nb-cells-label">cells</legend>
 
     {# the most consistent implementation would connect the input visibility to a form #}
-    <form name="visibility" id="nb-visibility"></form>
+    <form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label"></form>
 
     {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
     <table id="cells" role="presentation">

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -29,8 +29,7 @@
                 </th>
             </tr>
             <tr class="all">
-                <th scope="row"><span id="nb-visibility-label">visibility</span>
-                </th>
+                <th scope="row">visibility</th>
                 <td><input form="nb-visibility" aria-labelledby="nb-index-label nb-visibility-label" name="anchor"
                         type="checkbox" checked>
                 </td>
@@ -136,23 +135,10 @@
             {% block body_footer %}
         </tbody>
         <tfoot>
-            <tr>
-                <th class="nb-label" scope="col">label</th>
-                <th id="nb-index-label" scope="col">index</th>
-                <th id="nb-execution_count-label" scope="col">execution_count
-                </th>
-                <th id="nb-cell_type-label" scope="col">cell_type</th>
-                <th id="nb-source-label" scope="col">source</th>
-                <th id="nb-output-label" scope="col">output</th>
-                <th id="nb-metadata-label" scope="col">metadata</th>
-                <th id="nb-toolbar-label" scope="col">toolbar</th>
-                <th id="nb-loc-label" scope="col"><abbr title="lines of code">loc</abbr>
-                </th>
-            </tr>
             <tr class="total">
                 <th scope="row">all cells</th>
                 <th scope="row">count</th>
-                <td id="nb-ordered">{{ordered(nb)}}</td>
+                <td class="nb-ordered">{{ordered(nb)}}</td>
                 <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
                 <td class="nb-source"></td>
                 <td class="nb-outputs">{{count_outputs(nb)}}</td>
@@ -164,7 +150,7 @@
             <tr class="code">
                 <th scope="row">cpde cells</th>
                 <th scope="row">count</th>
-                <td id="nb-ordered">{{ordered(nb)}}</td>
+                <td class="nb-ordered">{{ordered(nb)}}</td>
                 <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
                 <td class="nb-source"></td>
                 <td class="nb-outputs">{{count_outputs(nb)}}</td>
@@ -175,7 +161,7 @@
             <tr class="markdown">
                 <th scope="row">markdown cells</th>
                 <th scope="row">count</th>
-                <td id="nb-ordered"></td>
+                <td class="nb-ordered"></td>
                 <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
                 <td class="nb-source"></td>
                 <td class="nb-outputs"></td>

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -1,26 +1,12 @@
 {%- extends 'semantic-forms/base.html.j2' -%}
 {% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
-{% macro cell_row(cell, loop) %}
-<tr role="listitem" class="cell {{cell.cell_type}}" aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
-    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
-    data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
-    <th role="none" class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
-    <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
-    <td role="none" class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
-    <td role="none" class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
-    <td role="none" class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
-        cell.execution_count)}}</td>
-    <td role="none" class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
-    <td role="none" class="nb-toolbar">{{cell_form(loop.index)}}</td>
-</tr>
-{% endmacro %}
 
 {% block body_header %}
 {{super()}}
 <fieldset name="cells" form="notebook" role="presentation" disabled>
     <legend aria-hidden="true" id="nb-cells-label">cells</legend>
-    <table id="cells" class="full-width" aria-labelledby="nb-cells-label">
+    <table id="cells" aria-labelledby="nb-cells-label">
         <caption hidden>cells</caption>
         <thead>
             <th class="nb-anchor" scope="col">index</th>
@@ -33,6 +19,8 @@
         </thead>
         <tbody role="list" aria-labelledby="nb-cells-label">
             {% endblock body_header %}
+
+            {% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}
 
             {% block body_footer %}
         </tbody>
@@ -57,9 +45,23 @@
                 <td class="metadata"></td>
             </tr>
         </tfoot>
-        </table>
+    </table>
 </fieldset>
 {{super()}}
 {% endblock body_footer %}
 
-{% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}
+{% macro cell_row(cell, loop) %}
+<tr role="listitem" class="cell {{cell.cell_type}}"
+    aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
+    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
+    data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
+    <th role="none" class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
+    <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
+    <td role="none" class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
+    <td role="none" class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
+    <td role="none" class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
+        cell.execution_count)}}</td>
+    <td role="none" class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
+    <td role="none" class="nb-toolbar">{{cell_form(loop.index)}}</td>
+</tr>
+{% endmacro %}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -3,17 +3,130 @@
 {% block body_header %}
 {{super()}}
 <fieldset name="cells" form="notebook" role="presentation" disabled>
+    {# the fieldset allows formal access to `document.forms["notebook"].elements["cells"]` #}
     <legend aria-hidden="true" id="nb-cells-label">cells</legend>
+
+    {# the most consistent implementation would connect the input visibility to a form #}
+    <form name="visibility" id="nb-visibility"></form>
+
+    {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
     <table id="cells" aria-labelledby="nb-cells-label">
-        <caption hidden>cells</caption>
+        <caption hidden>contents</caption>
         <thead>
-            <th class="nb-anchor" scope="col">index</th>
-            <th class="nb-execution_count" scope="col">execution_count</th>
-            <th class="nb-cell_type" scope="col">cell_type</th>
-            <th class="nb-source" scope="col">source</th>
-            <th class="nb-output" scope="col">output</th>
-            <th class="nb-metadata" scope="col">metadata</th>
-            <th class="nb-toolbar" scope="col">toolbar</th>
+            {# the table head is used to provide controls #}
+            {# it hints at a configurable pattern for showing different features. #}
+            {# there should be controls for each cell type here, and cell types can be added. #}
+            <tr>
+                <th class="nb-label" scope="col">label</th>
+                <th id="nb-index-label" scope="col">index</th>
+                <th id="nb-execution_count-label" scope="col">execution_count</th>
+                <th id="nb-cell_type-label" scope="col">cell_type</th>
+                <th id="nb-source-label" scope="col">source</th>
+                <th id="nb-output-label" scope="col">output</th>
+                <th id="nb-metadata-label" scope="col">metadata</th>
+                <th id="nb-toolbar-label" scope="col">toolbar</th>
+                <th id="nb-loc-label" scope="col"><abbr title="lines of code">loc</abbr>
+                </th>
+            </tr>
+            <tr class="all">
+                <th scope="row"><span id="nb-visibility-label">visibility</span>
+                </th>
+                <td><input form="nb-visibility" aria-labelledby="nb-index-label nb-visibility-label" name="anchor"
+                        type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-execution_count-label nb-visibility-label"
+                        name="execution_count" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-cell_type-label nb-visibility-label"
+                        name="cell_type" type="checkbox">
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-source-label nb-visibility-label" name="source"
+                        type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-output-label nb-visibility-label" name="output"
+                        type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-metadata-label nb-visibility-label" name="metadata"
+                        type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-toolbar-label nb-visibility-label" name="toolbar"
+                        type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-loc-label nb-visibility-label" name="loc"
+                        type="checkbox">
+                </td>
+            </tr>
+            <tr class="code">
+                <th scope="row"><span id="nb-code-label">code</span> <span id="nb-visibility-label">visibility</span>
+                </th>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-index-label nb-visibility-label"
+                        name="anchor" type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility"
+                        aria-labelledby="nb-code-label nb-execution_count-label nb-visibility-label"
+                        name="execution_count" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-cell_type-label nb-visibility-label"
+                        name="cell_type" type="checkbox">
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-source-label nb-visibility-label"
+                        name="source" type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-output-label nb-visibility-label"
+                        name="output" type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-metadata-label nb-visibility-label"
+                        name="metadata" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-toolbar-label nb-visibility-label"
+                        name="toolbar" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-loc-label nb-visibility-label"
+                        name="loc" type="checkbox">
+                </td>
+            </tr>
+            <tr class="markdown">
+                <th scope="row"><span id="nb-md-label">markdown</span> <span>visibility</span>
+                </th>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-index-label nb-visibility-label"
+                        name="anchor" type="checkbox" checked></td>
+                <td><input form="nb-visibility"
+                        aria-labelledby="nb-md-label nb-execution_count-label nb-visibility-label"
+                        name="execution_count" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-cell_type-label nb-visibility-label"
+                        name="cell_type" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-source-label nb-visibility-label"
+                        name="source" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-output-label nb-visibility-label"
+                        name="output" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-metadata-label nb-visibility-label"
+                        name="metadata" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-toolbar-label nb-visibility-label"
+                        name="toolbar" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-loc-label nb-visibility-label"
+                        name="toolbar" type="checkbox"></td>
+            </tr>
+            <tr>
+                <th scope="row">description</th>
+                <td>
+                    <p id="nb-index-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-execution_count-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-cell_type-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-source-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-output-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-metadata-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-toolbar-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-loc-desc">significant lines of code in the cell source</p>
+                </td>
+            </tr>
         </thead>
         <tbody role="list" aria-labelledby="nb-cells-label">
             {% endblock body_header %}
@@ -24,23 +137,51 @@
         </tbody>
         <tfoot>
             <tr>
-                <th>cells</th>
-                <th id="nb-code-cells-label">code cells</th>
-                <th id="nb-ordered-label">state</th>
-                <th class="cell_type"></th>
-                <th id="nb-loc-label"><abbr title="lines of code" aria-hidden="true">LOC</abbr><span hidden>lines of
-                        code</span></th>
-                <th id="nb-outputs-label">outputs</th>
-                <th class="metadata"></th>
+                <th class="nb-label" scope="col">label</th>
+                <th id="nb-index-label" scope="col">index</th>
+                <th id="nb-execution_count-label" scope="col">execution_count
+                </th>
+                <th id="nb-cell_type-label" scope="col">cell_type</th>
+                <th id="nb-source-label" scope="col">source</th>
+                <th id="nb-output-label" scope="col">output</th>
+                <th id="nb-metadata-label" scope="col">metadata</th>
+                <th id="nb-toolbar-label" scope="col">toolbar</th>
+                <th id="nb-loc-label" scope="col"><abbr title="lines of code">loc</abbr>
+                </th>
             </tr>
-            <tr>
-                <td id="nb-cells-count-label">{{nb.cells.__len__()}}</td>
-                <td id="nb-code-cells-count">{{count_code_cells(nb)}}</td>
+            <tr class="total">
+                <th scope="row">all cells</th>
+                <th scope="row">count</th>
                 <td id="nb-ordered">{{ordered(nb)}}</td>
-                <td class="cell_type"></td>
-                <td id="nb-loc">{{count_loc(nb)}}</td>
-                <td id="nb-outputs">{{count_outputs(nb)}}</td>
-                <td class="metadata"></td>
+                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                <td class="nb-source"></td>
+                <td class="nb-outputs">{{count_outputs(nb)}}</td>
+                <td class="nb-toolbar"></td>
+                <td class="nb-metadata">{# list keys #}</td>
+                <td class="nb-loc">{{count_loc(nb)}}</td>
+
+            </tr>
+            <tr class="code">
+                <th scope="row">cpde cells</th>
+                <th scope="row">count</th>
+                <td id="nb-ordered">{{ordered(nb)}}</td>
+                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                <td class="nb-source"></td>
+                <td class="nb-outputs">{{count_outputs(nb)}}</td>
+                <td class="nb-toolbar"></td>
+                <td class="nb-metadata">{# list keys #}</td>
+                <td class="nb-loc">{{count_loc(nb)}}</td>
+            </tr>
+            <tr class="markdown">
+                <th scope="row">markdown cells</th>
+                <th scope="row">count</th>
+                <td id="nb-ordered"></td>
+                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                <td class="nb-source"></td>
+                <td class="nb-outputs"></td>
+                <td class="nb-toolbar"></td>
+                <td class="nb-metadata">{# list keys #}</td>
+                <td class="nb-loc">{{count_loc(nb)}}</td>
             </tr>
         </tfoot>
     </table>
@@ -48,11 +189,14 @@
 {{super()}}
 {% endblock body_footer %}
 
+{% macro loc(cell) %}{{cell.source.splitlines().__len__()}}{% endmacro%}
+
 {% macro cell_row(cell, loop) %}
 <tr role="listitem" class="cell {{cell.cell_type}}"
     aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
     data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
     data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
+    <th role="none" class="nb-label" scope="row">{{cell.cell_type}} cell</th>
     <th role="none" class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
     <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
     <td role="none" class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
@@ -61,5 +205,6 @@
         cell.execution_count)}}</td>
     <td role="none" class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
     <td role="none" class="nb-toolbar">{{cell_form(loop.index)}}</td>
+    <td role="none" class="nb-loc">{{loc(cell)}}</td>
 </tr>
 {% endmacro %}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -1,11 +1,11 @@
-{%- extends 'semantic-forms/main.html.j2' -%}
+{%- extends 'semantic-forms/base.html.j2' -%}
 {% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
 {% macro cell_row(cell, loop) %}
-<tr role="region" class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
+<tr role="listitem" class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
     data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
     data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
-    <td role="none" class="anchor">{{cell_anchor(loop.index)}}</td>
+    <th role="none" class="anchor" scope="row">{{cell_anchor(loop.index)}}</th>
     <td role="none" class="toolbar">{{cell_form(loop.index)}}</td>
     <td role="none" class="execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
     <td role="none" class="cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
@@ -18,23 +18,47 @@
 
 {% block body_header %}
 {{super()}}
-<table role="document">
-    <caption>Notebook</caption>
-    <thead>
-        <th class="anchor">index</th>
-        <th class="toolbar">toolbar</th>
-        <th class="execution_count">execution_count</th>
-        <th class="cell_type">cell_type</th>
-        <th class="source">source</th>
-        <th class="output">output</th>
-        <th class="metadata">metadata</th>
-    </thead>
-    <tbody>
-        {% endblock body_header %}
+<fieldset name="cells" form="notebook" role="presentation" disabled>
+    <legend aria-hidden="true" id="nb-cells-label">cells</legend>
+    <table role="group" id="cells" class="full-width" aria-labelledby="nb-cells-label">
+        <caption hidden>cells</caption>
+        <thead>
+            <th class="anchor" scope="col">index</th>
+            <th class="toolbar" scope="col">toolbar</th>
+            <th class="execution_count" scope="col">execution_count</th>
+            <th class="cell_type" scope="col">cell_type</th>
+            <th class="source" scope="col">source</th>
+            <th class="output" scope="col">output</th>
+            <th class="metadata" scope="col">metadata</th>
+        </thead>
+        <tbody role="list" aria-labelledby="nb-cells-label">
+            {% endblock body_header %}
 
-        {% block body_footer %}
-    </tbody>
-</table>
+            {% block body_footer %}
+        </tbody>
+        <tfoot>
+            <tr>
+                <th id="nb-cells-label">cells</th>
+                <th id="nb-code-cells-label">code cells</th>
+                <th id="nb-ordered-label">state</th>
+                <th class="cell_type"></th>
+                <th id="nb-loc-label"><abbr title="lines of code" aria-hidden="true">LOC</abbr><span hidden>lines of
+                        code</span></th>
+                <th id="nb-outputs-label">outputs</th>
+                <th class="metadata"></th>
+            </tr>
+            <tr>
+                <td id="nb-cells-count-label">{{nb.cells.__len__()}}</td>
+                <td id="nb-code-cells-count">{{count_code_cells(nb)}}</td>
+                <td id="nb-ordered">{{ordered(nb)}}</td>
+                <td class="cell_type"></td>
+                <td id="nb-loc">{{count_loc(nb)}}</td>
+                <td id="nb-outputs">{{count_outputs(nb)}}</td>
+                <td class="metadata"></td>
+            </tr>
+        </tfoot>
+        </table>
+</fieldset>
 {{super()}}
 {% endblock body_footer %}
 

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -20,7 +20,7 @@
 {{super()}}
 <fieldset name="cells" form="notebook" role="presentation" disabled>
     <legend aria-hidden="true" id="nb-cells-label">cells</legend>
-    <table role="group" id="cells" class="full-width" aria-labelledby="nb-cells-label">
+    <table role="main" id="cells" class="full-width" aria-labelledby="nb-cells-label">
         <caption hidden>cells</caption>
         <thead>
             <th class="nb-anchor" scope="col">index</th>

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -10,7 +10,7 @@
     <form name="visibility" id="nb-visibility"></form>
 
     {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
-    <table id="cells" aria-labelledby="nb-cells-label" role="group">
+    <table id="cells" role="presentation">
         <caption hidden>contents</caption>
         <thead>
             {# the table head is used to provide controls #}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -20,7 +20,7 @@
 {{super()}}
 <fieldset name="cells" form="notebook" role="presentation" disabled>
     <legend aria-hidden="true" id="nb-cells-label">cells</legend>
-    <table role="main" id="cells" class="full-width" aria-labelledby="nb-cells-label">
+    <table role="group" id="cells" class="full-width" aria-labelledby="nb-cells-label">
         <caption hidden>cells</caption>
         <thead>
             <th class="nb-anchor" scope="col">index</th>

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -20,7 +20,7 @@
 {{super()}}
 <fieldset name="cells" form="notebook" role="presentation" disabled>
     <legend aria-hidden="true" id="nb-cells-label">cells</legend>
-    <table role="group" id="cells" class="full-width" aria-labelledby="nb-cells-label">
+    <table id="cells" class="full-width" aria-labelledby="nb-cells-label">
         <caption hidden>cells</caption>
         <thead>
             <th class="nb-anchor" scope="col">index</th>

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -2,17 +2,17 @@
 {% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 
 {% macro cell_row(cell, loop) %}
-<tr role="listitem" class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
+<tr role="listitem" class="cell {{cell.cell_type}}" aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
     data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
     data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
-    <th role="none" class="anchor" scope="row">{{cell_anchor(loop.index)}}</th>
-    <td role="none" class="toolbar">{{cell_form(loop.index)}}</td>
-    <td role="none" class="execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
-    <td role="none" class="cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
-    <td role="none" class="source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
-    <td role="none" class="output">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
+    <th role="none" class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
+    <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
+    <td role="none" class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
+    <td role="none" class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
+    <td role="none" class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
         cell.execution_count)}}</td>
-    <td role="none" class="metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
+    <td role="none" class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
+    <td role="none" class="nb-toolbar">{{cell_form(loop.index)}}</td>
 </tr>
 {% endmacro %}
 
@@ -23,13 +23,13 @@
     <table role="group" id="cells" class="full-width" aria-labelledby="nb-cells-label">
         <caption hidden>cells</caption>
         <thead>
-            <th class="anchor" scope="col">index</th>
-            <th class="toolbar" scope="col">toolbar</th>
-            <th class="execution_count" scope="col">execution_count</th>
-            <th class="cell_type" scope="col">cell_type</th>
-            <th class="source" scope="col">source</th>
-            <th class="output" scope="col">output</th>
-            <th class="metadata" scope="col">metadata</th>
+            <th class="nb-anchor" scope="col">index</th>
+            <th class="nb-execution_count" scope="col">execution_count</th>
+            <th class="nb-cell_type" scope="col">cell_type</th>
+            <th class="nb-source" scope="col">source</th>
+            <th class="nb-output" scope="col">output</th>
+            <th class="nb-metadata" scope="col">metadata</th>
+            <th class="nb-toolbar" scope="col">toolbar</th>
         </thead>
         <tbody role="list" aria-labelledby="nb-cells-label">
             {% endblock body_header %}
@@ -38,7 +38,7 @@
         </tbody>
         <tfoot>
             <tr>
-                <th id="nb-cells-label">cells</th>
+                <th>cells</th>
                 <th id="nb-code-cells-label">code cells</th>
                 <th id="nb-ordered-label">state</th>
                 <th class="cell_type"></th>

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -7,154 +7,167 @@
         <legend aria-hidden="true" id="nb-cells-label">cells</legend>
 
         {# the most consistent implementation would connect the input visibility to a form #}
-        <form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label"></form>
+        <form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label">
+                <button>toggle <span id="nb-visibility-label">visibility</span></button>
 
-        {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
+                {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
+                <table aria-labelledby="nb-visibility-label" role="grid" hidden>
+                        <tbody>
+                                {# the table head is used to provide controls #}
+                                {# it hints at a configurable pattern for showing different features. #}
+                                {# there should be controls for each cell type here, and cell types can be added. #}
+                                <tr>
+                                        <td id="nb-cell-label">cell</td>
+                                        <td id="nb-index-label">index</td>
+                                        <td id="nb-execution_count-label">execution_count</td>
+                                        <td id="nb-cell_type-label">cell_type</td>
+                                        <td id="nb-source-label">source</td>
+                                        <td id="nb-output-label">output</td>
+                                        <td id="nb-metadata-label">metadata</td>
+                                        <td id="nb-toolbar-label">toolbar</td>
+                                        <td id="nb-loc-label"><abbr title="lines of code">loc</abbr>
+                                        </td>
+                                </tr>
+                                <tr class="all">
+                                        <td>all</td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-index-label nb-visibility-label"
+                                                        name="anchor" type="checkbox" checked>
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-execution_count-label nb-visibility-label"
+                                                        name="execution_count" type="checkbox" checked></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-cell_type-label nb-visibility-label"
+                                                        name="cell_type" type="checkbox">
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-source-label nb-visibility-label"
+                                                        name="source" type="checkbox" checked>
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-output-label nb-visibility-label"
+                                                        name="output" type="checkbox" checked>
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-metadata-label nb-visibility-label"
+                                                        name="metadata" type="checkbox"></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-toolbar-label nb-visibility-label"
+                                                        name="toolbar" type="checkbox"></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-loc-label nb-visibility-label" name="loc"
+                                                        type="checkbox">
+                                        </td>
+                                </tr>
+                                <tr class="code">
+                                        <td id="nb-code-label">code</td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-index-label nb-visibility-label"
+                                                        name="anchor" type="checkbox" checked>
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-execution_count-label nb-visibility-label"
+                                                        name="execution_count" type="checkbox" checked></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-cell_type-label nb-visibility-label"
+                                                        name="cell_type" type="checkbox">
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-source-label nb-visibility-label"
+                                                        name="source" type="checkbox" checked>
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-output-label nb-visibility-label"
+                                                        name="output" type="checkbox" checked>
+                                        </td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-metadata-label nb-visibility-label"
+                                                        name="metadata" type="checkbox"></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-toolbar-label nb-visibility-label"
+                                                        name="toolbar" type="checkbox"></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-code-label nb-loc-label nb-visibility-label"
+                                                        name="loc" type="checkbox">
+                                        </td>
+                                </tr>
+                                <tr class="markdown">
+                                        <td id="nb-md-label">markdown</td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-index-label nb-visibility-label"
+                                                        name="anchor" type="checkbox" checked></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-execution_count-label nb-visibility-label"
+                                                        name="execution_count" type="checkbox" checked></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-cell_type-label nb-visibility-label"
+                                                        name="cell_type" type="checkbox"></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-source-label nb-visibility-label"
+                                                        name="source" type="checkbox" checked></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-output-label nb-visibility-label"
+                                                        name="output" type="checkbox" checked></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-metadata-label nb-visibility-label"
+                                                        name="metadata" type="checkbox"></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-toolbar-label nb-visibility-label"
+                                                        name="toolbar" type="checkbox"></td>
+                                        <td><input form="nb-visibility"
+                                                        aria-labelledby="nb-md-label nb-loc-label nb-visibility-label"
+                                                        name="toolbar" type="checkbox"></td>
+                                </tr>
+                                <tr class="nb-column-descriptions">
+                                        <td id="nb-description-label">description</td>
+
+                                        <td>
+                                                <p id="nb-index-desc"></p>
+                                        </td>
+                                        <td>
+                                                <p id="nb-execution_count-desc"></p>
+                                        </td>
+                                        <td>
+                                                <p id="nb-cell_type-desc"></p>
+                                        </td>
+                                        <td>
+                                                <p id="nb-source-desc"></p>
+                                        </td>
+                                        <td>
+                                                <p id="nb-output-desc"></p>
+                                        </td>
+                                        <td>
+                                                <p id="nb-metadata-desc"></p>
+                                        </td>
+                                        <td>
+                                                <p id="nb-toolbar-desc"></p>
+                                        </td>
+                                        <td>
+                                                <p id="nb-loc-desc">significant lines of code in the cell source</p>
+                                        </td>
+                                </tr>
+                        </tbody>
+                </table>
+        </form>
         <table id="cells" role="presentation">
-                {# the table caption is removed because testing on VoiceOver iOS encountered
-                https://developer.apple.com/forums/thread/679841
+                <tbody role="list">
+                        {# the table caption is removed because testing on VoiceOver iOS encountered
+                        https://developer.apple.com/forums/thread/679841
 
-                the best course of action is to remove the caption and provide label support with aria. #}
-                {# <caption hidden>contents</caption> #}
-                <thead>
-                        {# the table head is used to provide controls #}
-                        {# it hints at a configurable pattern for showing different features. #}
-                        {# there should be controls for each cell type here, and cell types can be added. #}
-                        <tr>
-                                <th class="nb-label" scope="col">label</th>
-                                <th id="nb-index-label" scope="col">index</th>
-                                <th id="nb-execution_count-label" scope="col">execution_count</th>
-                                <th id="nb-cell_type-label" scope="col">cell_type</th>
-                                <th id="nb-source-label" scope="col">source</th>
-                                <th id="nb-output-label" scope="col">output</th>
-                                <th id="nb-metadata-label" scope="col">metadata</th>
-                                <th id="nb-toolbar-label" scope="col">toolbar</th>
-                                <th id="nb-loc-label" scope="col"><abbr title="lines of code">loc</abbr>
-                                </th>
-                        </tr>
-                        <tr class="all">
-                                <th scope="row">visibility</th>
-                                <td><input form="nb-visibility" aria-labelledby="nb-index-label nb-visibility-label"
-                                                name="anchor" type="checkbox" checked>
-                                </td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-execution_count-label nb-visibility-label"
-                                                name="execution_count" type="checkbox" checked></td>
-                                <td><input form="nb-visibility" aria-labelledby="nb-cell_type-label nb-visibility-label"
-                                                name="cell_type" type="checkbox">
-                                </td>
-                                <td><input form="nb-visibility" aria-labelledby="nb-source-label nb-visibility-label"
-                                                name="source" type="checkbox" checked>
-                                </td>
-                                <td><input form="nb-visibility" aria-labelledby="nb-output-label nb-visibility-label"
-                                                name="output" type="checkbox" checked>
-                                </td>
-                                <td><input form="nb-visibility" aria-labelledby="nb-metadata-label nb-visibility-label"
-                                                name="metadata" type="checkbox"></td>
-                                <td><input form="nb-visibility" aria-labelledby="nb-toolbar-label nb-visibility-label"
-                                                name="toolbar" type="checkbox"></td>
-                                <td><input form="nb-visibility" aria-labelledby="nb-loc-label nb-visibility-label"
-                                                name="loc" type="checkbox">
-                                </td>
-                        </tr>
-                        <tr class="code">
-                                <th scope="row"><span id="nb-code-label">code</span> <span
-                                                id="nb-visibility-label">visibility</span>
-                                </th>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-index-label nb-visibility-label"
-                                                name="anchor" type="checkbox" checked>
-                                </td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-execution_count-label nb-visibility-label"
-                                                name="execution_count" type="checkbox" checked></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-cell_type-label nb-visibility-label"
-                                                name="cell_type" type="checkbox">
-                                </td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-source-label nb-visibility-label"
-                                                name="source" type="checkbox" checked>
-                                </td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-output-label nb-visibility-label"
-                                                name="output" type="checkbox" checked>
-                                </td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-metadata-label nb-visibility-label"
-                                                name="metadata" type="checkbox"></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-toolbar-label nb-visibility-label"
-                                                name="toolbar" type="checkbox"></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-code-label nb-loc-label nb-visibility-label"
-                                                name="loc" type="checkbox">
-                                </td>
-                        </tr>
-                        <tr class="markdown">
-                                <th scope="row"><span id="nb-md-label">markdown</span> <span>visibility</span>
-                                </th>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-index-label nb-visibility-label"
-                                                name="anchor" type="checkbox" checked></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-execution_count-label nb-visibility-label"
-                                                name="execution_count" type="checkbox" checked></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-cell_type-label nb-visibility-label"
-                                                name="cell_type" type="checkbox"></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-source-label nb-visibility-label"
-                                                name="source" type="checkbox" checked></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-output-label nb-visibility-label"
-                                                name="output" type="checkbox" checked></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-metadata-label nb-visibility-label"
-                                                name="metadata" type="checkbox"></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-toolbar-label nb-visibility-label"
-                                                name="toolbar" type="checkbox"></td>
-                                <td><input form="nb-visibility"
-                                                aria-labelledby="nb-md-label nb-loc-label nb-visibility-label"
-                                                name="toolbar" type="checkbox"></td>
-                        </tr>
-                        <tr>
-                                <th scope="row">description</th>
-                                <td>
-                                        <p id="nb-index-desc"></p>
-                                </td>
-                                <td>
-                                        <p id="nb-execution_count-desc"></p>
-                                </td>
-                                <td>
-                                        <p id="nb-cell_type-desc"></p>
-                                </td>
-                                <td>
-                                        <p id="nb-source-desc"></p>
-                                </td>
-                                <td>
-                                        <p id="nb-output-desc"></p>
-                                </td>
-                                <td>
-                                        <p id="nb-metadata-desc"></p>
-                                </td>
-                                <td>
-                                        <p id="nb-toolbar-desc"></p>
-                                </td>
-                                <td>
-                                        <p id="nb-loc-desc">significant lines of code in the cell source</p>
-                                </td>
-                        </tr>
-                </thead>
-                <tbody role="list" aria-labelledby="nb-cells-label">
+                        the best course of action is to remove the caption and provide label support with aria.
+                        we wont use captions on any tables for this reason. #}
+                        {# <caption hidden>contents</caption> #}
                         {% endblock body_header %}
 
                         {% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}
 
                         {% block body_footer %}
                 </tbody>
-                <tfoot>
+        </table>
+        <table class="nb-cells-footer" hidden>
+                <tbody>
+                        {# needs a header row #}
                         <tr class="total">
                                 <th scope="row">all cells</th>
                                 <th scope="row">count</th>
@@ -189,7 +202,7 @@
                                 <td class="nb-metadata">{# list keys #}</td>
                                 <td class="nb-loc">{{count_loc(nb)}}</td>
                         </tr>
-                </tfoot>
+                </tbody>
         </table>
 </fieldset>
 {{super()}}
@@ -202,8 +215,7 @@
         aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
         data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
         data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
-        <th class="nb-label" scope="row">{{cell.cell_type}} cell</th>
-        <th class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
+        <td class="nb-index">{{cell_anchor(loop.index)}}</td>
         <td class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
         <td class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
         <td class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -10,7 +10,7 @@
     <form name="visibility" id="nb-visibility"></form>
 
     {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
-    <table id="cells" aria-labelledby="nb-cells-label">
+    <table id="cells" aria-labelledby="nb-cells-label" role="group">
         <caption hidden>contents</caption>
         <thead>
             {# the table head is used to provide controls #}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -11,7 +11,7 @@
 
     {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
     <table id="cells" role="presentation">
-        <caption hidden>contents</caption>
+        {# <caption hidden>contents</caption> #}
         <thead>
             {# the table head is used to provide controls #}
             {# it hints at a configurable pattern for showing different features. #}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -3,174 +3,194 @@
 {% block body_header %}
 {{super()}}
 <fieldset name="cells" form="notebook" role="presentation" disabled>
-    {# the fieldset allows formal access to `document.forms["notebook"].elements["cells"]` #}
-    <legend aria-hidden="true" id="nb-cells-label">cells</legend>
+        {# the fieldset allows formal access to `document.forms["notebook"].elements["cells"]` #}
+        <legend aria-hidden="true" id="nb-cells-label">cells</legend>
 
-    {# the most consistent implementation would connect the input visibility to a form #}
-    <form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label"></form>
+        {# the most consistent implementation would connect the input visibility to a form #}
+        <form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label"></form>
 
-    {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
-    <table id="cells" role="presentation">
-        {# <caption hidden>contents</caption> #}
-        <thead>
-            {# the table head is used to provide controls #}
-            {# it hints at a configurable pattern for showing different features. #}
-            {# there should be controls for each cell type here, and cell types can be added. #}
-            <tr>
-                <th class="nb-label" scope="col">label</th>
-                <th id="nb-index-label" scope="col">index</th>
-                <th id="nb-execution_count-label" scope="col">execution_count</th>
-                <th id="nb-cell_type-label" scope="col">cell_type</th>
-                <th id="nb-source-label" scope="col">source</th>
-                <th id="nb-output-label" scope="col">output</th>
-                <th id="nb-metadata-label" scope="col">metadata</th>
-                <th id="nb-toolbar-label" scope="col">toolbar</th>
-                <th id="nb-loc-label" scope="col"><abbr title="lines of code">loc</abbr>
-                </th>
-            </tr>
-            <tr class="all">
-                <th scope="row">visibility</th>
-                <td><input form="nb-visibility" aria-labelledby="nb-index-label nb-visibility-label" name="anchor"
-                        type="checkbox" checked>
-                </td>
-                <td><input form="nb-visibility" aria-labelledby="nb-execution_count-label nb-visibility-label"
-                        name="execution_count" type="checkbox" checked></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-cell_type-label nb-visibility-label"
-                        name="cell_type" type="checkbox">
-                </td>
-                <td><input form="nb-visibility" aria-labelledby="nb-source-label nb-visibility-label" name="source"
-                        type="checkbox" checked>
-                </td>
-                <td><input form="nb-visibility" aria-labelledby="nb-output-label nb-visibility-label" name="output"
-                        type="checkbox" checked>
-                </td>
-                <td><input form="nb-visibility" aria-labelledby="nb-metadata-label nb-visibility-label" name="metadata"
-                        type="checkbox"></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-toolbar-label nb-visibility-label" name="toolbar"
-                        type="checkbox"></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-loc-label nb-visibility-label" name="loc"
-                        type="checkbox">
-                </td>
-            </tr>
-            <tr class="code">
-                <th scope="row"><span id="nb-code-label">code</span> <span id="nb-visibility-label">visibility</span>
-                </th>
-                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-index-label nb-visibility-label"
-                        name="anchor" type="checkbox" checked>
-                </td>
-                <td><input form="nb-visibility"
-                        aria-labelledby="nb-code-label nb-execution_count-label nb-visibility-label"
-                        name="execution_count" type="checkbox" checked></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-cell_type-label nb-visibility-label"
-                        name="cell_type" type="checkbox">
-                </td>
-                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-source-label nb-visibility-label"
-                        name="source" type="checkbox" checked>
-                </td>
-                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-output-label nb-visibility-label"
-                        name="output" type="checkbox" checked>
-                </td>
-                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-metadata-label nb-visibility-label"
-                        name="metadata" type="checkbox"></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-toolbar-label nb-visibility-label"
-                        name="toolbar" type="checkbox"></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-loc-label nb-visibility-label"
-                        name="loc" type="checkbox">
-                </td>
-            </tr>
-            <tr class="markdown">
-                <th scope="row"><span id="nb-md-label">markdown</span> <span>visibility</span>
-                </th>
-                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-index-label nb-visibility-label"
-                        name="anchor" type="checkbox" checked></td>
-                <td><input form="nb-visibility"
-                        aria-labelledby="nb-md-label nb-execution_count-label nb-visibility-label"
-                        name="execution_count" type="checkbox" checked></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-cell_type-label nb-visibility-label"
-                        name="cell_type" type="checkbox"></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-source-label nb-visibility-label"
-                        name="source" type="checkbox" checked></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-output-label nb-visibility-label"
-                        name="output" type="checkbox" checked></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-metadata-label nb-visibility-label"
-                        name="metadata" type="checkbox"></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-toolbar-label nb-visibility-label"
-                        name="toolbar" type="checkbox"></td>
-                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-loc-label nb-visibility-label"
-                        name="toolbar" type="checkbox"></td>
-            </tr>
-            <tr>
-                <th scope="row">description</th>
-                <td>
-                    <p id="nb-index-desc"></p>
-                </td>
-                <td>
-                    <p id="nb-execution_count-desc"></p>
-                </td>
-                <td>
-                    <p id="nb-cell_type-desc"></p>
-                </td>
-                <td>
-                    <p id="nb-source-desc"></p>
-                </td>
-                <td>
-                    <p id="nb-output-desc"></p>
-                </td>
-                <td>
-                    <p id="nb-metadata-desc"></p>
-                </td>
-                <td>
-                    <p id="nb-toolbar-desc"></p>
-                </td>
-                <td>
-                    <p id="nb-loc-desc">significant lines of code in the cell source</p>
-                </td>
-            </tr>
-        </thead>
-        <tbody role="list" aria-labelledby="nb-cells-label">
-            {% endblock body_header %}
+        {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
+        <table id="cells" role="presentation">
+                {# the table caption is removed because testing on VoiceOver iOS encountered
+                https://developer.apple.com/forums/thread/679841
 
-            {% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}
+                the best course of action is to remove the caption and provide label support with aria. #}
+                {# <caption hidden>contents</caption> #}
+                <thead>
+                        {# the table head is used to provide controls #}
+                        {# it hints at a configurable pattern for showing different features. #}
+                        {# there should be controls for each cell type here, and cell types can be added. #}
+                        <tr>
+                                <th class="nb-label" scope="col">label</th>
+                                <th id="nb-index-label" scope="col">index</th>
+                                <th id="nb-execution_count-label" scope="col">execution_count</th>
+                                <th id="nb-cell_type-label" scope="col">cell_type</th>
+                                <th id="nb-source-label" scope="col">source</th>
+                                <th id="nb-output-label" scope="col">output</th>
+                                <th id="nb-metadata-label" scope="col">metadata</th>
+                                <th id="nb-toolbar-label" scope="col">toolbar</th>
+                                <th id="nb-loc-label" scope="col"><abbr title="lines of code">loc</abbr>
+                                </th>
+                        </tr>
+                        <tr class="all">
+                                <th scope="row">visibility</th>
+                                <td><input form="nb-visibility" aria-labelledby="nb-index-label nb-visibility-label"
+                                                name="anchor" type="checkbox" checked>
+                                </td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-execution_count-label nb-visibility-label"
+                                                name="execution_count" type="checkbox" checked></td>
+                                <td><input form="nb-visibility" aria-labelledby="nb-cell_type-label nb-visibility-label"
+                                                name="cell_type" type="checkbox">
+                                </td>
+                                <td><input form="nb-visibility" aria-labelledby="nb-source-label nb-visibility-label"
+                                                name="source" type="checkbox" checked>
+                                </td>
+                                <td><input form="nb-visibility" aria-labelledby="nb-output-label nb-visibility-label"
+                                                name="output" type="checkbox" checked>
+                                </td>
+                                <td><input form="nb-visibility" aria-labelledby="nb-metadata-label nb-visibility-label"
+                                                name="metadata" type="checkbox"></td>
+                                <td><input form="nb-visibility" aria-labelledby="nb-toolbar-label nb-visibility-label"
+                                                name="toolbar" type="checkbox"></td>
+                                <td><input form="nb-visibility" aria-labelledby="nb-loc-label nb-visibility-label"
+                                                name="loc" type="checkbox">
+                                </td>
+                        </tr>
+                        <tr class="code">
+                                <th scope="row"><span id="nb-code-label">code</span> <span
+                                                id="nb-visibility-label">visibility</span>
+                                </th>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-index-label nb-visibility-label"
+                                                name="anchor" type="checkbox" checked>
+                                </td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-execution_count-label nb-visibility-label"
+                                                name="execution_count" type="checkbox" checked></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-cell_type-label nb-visibility-label"
+                                                name="cell_type" type="checkbox">
+                                </td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-source-label nb-visibility-label"
+                                                name="source" type="checkbox" checked>
+                                </td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-output-label nb-visibility-label"
+                                                name="output" type="checkbox" checked>
+                                </td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-metadata-label nb-visibility-label"
+                                                name="metadata" type="checkbox"></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-toolbar-label nb-visibility-label"
+                                                name="toolbar" type="checkbox"></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-code-label nb-loc-label nb-visibility-label"
+                                                name="loc" type="checkbox">
+                                </td>
+                        </tr>
+                        <tr class="markdown">
+                                <th scope="row"><span id="nb-md-label">markdown</span> <span>visibility</span>
+                                </th>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-index-label nb-visibility-label"
+                                                name="anchor" type="checkbox" checked></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-execution_count-label nb-visibility-label"
+                                                name="execution_count" type="checkbox" checked></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-cell_type-label nb-visibility-label"
+                                                name="cell_type" type="checkbox"></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-source-label nb-visibility-label"
+                                                name="source" type="checkbox" checked></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-output-label nb-visibility-label"
+                                                name="output" type="checkbox" checked></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-metadata-label nb-visibility-label"
+                                                name="metadata" type="checkbox"></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-toolbar-label nb-visibility-label"
+                                                name="toolbar" type="checkbox"></td>
+                                <td><input form="nb-visibility"
+                                                aria-labelledby="nb-md-label nb-loc-label nb-visibility-label"
+                                                name="toolbar" type="checkbox"></td>
+                        </tr>
+                        <tr>
+                                <th scope="row">description</th>
+                                <td>
+                                        <p id="nb-index-desc"></p>
+                                </td>
+                                <td>
+                                        <p id="nb-execution_count-desc"></p>
+                                </td>
+                                <td>
+                                        <p id="nb-cell_type-desc"></p>
+                                </td>
+                                <td>
+                                        <p id="nb-source-desc"></p>
+                                </td>
+                                <td>
+                                        <p id="nb-output-desc"></p>
+                                </td>
+                                <td>
+                                        <p id="nb-metadata-desc"></p>
+                                </td>
+                                <td>
+                                        <p id="nb-toolbar-desc"></p>
+                                </td>
+                                <td>
+                                        <p id="nb-loc-desc">significant lines of code in the cell source</p>
+                                </td>
+                        </tr>
+                </thead>
+                <tbody role="list" aria-labelledby="nb-cells-label">
+                        {% endblock body_header %}
 
-            {% block body_footer %}
-        </tbody>
-        <tfoot>
-            <tr class="total">
-                <th scope="row">all cells</th>
-                <th scope="row">count</th>
-                <td class="nb-ordered">{{ordered(nb)}}</td>
-                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-                <td class="nb-source"></td>
-                <td class="nb-outputs">{{count_outputs(nb)}}</td>
-                <td class="nb-toolbar"></td>
-                <td class="nb-metadata">{# list keys #}</td>
-                <td class="nb-loc">{{count_loc(nb)}}</td>
+                        {% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}
 
-            </tr>
-            <tr class="code">
-                <th scope="row">cpde cells</th>
-                <th scope="row">count</th>
-                <td class="nb-ordered">{{ordered(nb)}}</td>
-                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-                <td class="nb-source"></td>
-                <td class="nb-outputs">{{count_outputs(nb)}}</td>
-                <td class="nb-toolbar"></td>
-                <td class="nb-metadata">{# list keys #}</td>
-                <td class="nb-loc">{{count_loc(nb)}}</td>
-            </tr>
-            <tr class="markdown">
-                <th scope="row">markdown cells</th>
-                <th scope="row">count</th>
-                <td class="nb-ordered"></td>
-                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-                <td class="nb-source"></td>
-                <td class="nb-outputs"></td>
-                <td class="nb-toolbar"></td>
-                <td class="nb-metadata">{# list keys #}</td>
-                <td class="nb-loc">{{count_loc(nb)}}</td>
-            </tr>
-        </tfoot>
-    </table>
+                        {% block body_footer %}
+                </tbody>
+                <tfoot>
+                        <tr class="total">
+                                <th scope="row">all cells</th>
+                                <th scope="row">count</th>
+                                <td class="nb-ordered">{{ordered(nb)}}</td>
+                                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                                <td class="nb-source"></td>
+                                <td class="nb-outputs">{{count_outputs(nb)}}</td>
+                                <td class="nb-toolbar"></td>
+                                <td class="nb-metadata">{# list keys #}</td>
+                                <td class="nb-loc">{{count_loc(nb)}}</td>
+
+                        </tr>
+                        <tr class="code">
+                                <th scope="row">cpde cells</th>
+                                <th scope="row">count</th>
+                                <td class="nb-ordered">{{ordered(nb)}}</td>
+                                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                                <td class="nb-source"></td>
+                                <td class="nb-outputs">{{count_outputs(nb)}}</td>
+                                <td class="nb-toolbar"></td>
+                                <td class="nb-metadata">{# list keys #}</td>
+                                <td class="nb-loc">{{count_loc(nb)}}</td>
+                        </tr>
+                        <tr class="markdown">
+                                <th scope="row">markdown cells</th>
+                                <th scope="row">count</th>
+                                <td class="nb-ordered"></td>
+                                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                                <td class="nb-source"></td>
+                                <td class="nb-outputs"></td>
+                                <td class="nb-toolbar"></td>
+                                <td class="nb-metadata">{# list keys #}</td>
+                                <td class="nb-loc">{{count_loc(nb)}}</td>
+                        </tr>
+                </tfoot>
+        </table>
 </fieldset>
 {{super()}}
 {% endblock body_footer %}
@@ -179,18 +199,18 @@
 
 {% macro cell_row(cell, loop) %}
 <tr role="listitem" class="cell {{cell.cell_type}}"
-    aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
-    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
-    data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
-    <th role="none" class="nb-label" scope="row">{{cell.cell_type}} cell</th>
-    <th role="none" class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
-    <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
-    <td role="none" class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
-    <td role="none" class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
-    <td role="none" class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
-        cell.execution_count)}}</td>
-    <td role="none" class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
-    <td role="none" class="nb-toolbar">{{cell_form(loop.index)}}</td>
-    <td role="none" class="nb-loc">{{loc(cell)}}</td>
+        aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
+        data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
+        data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
+        <th role="none" class="nb-label" scope="row">{{cell.cell_type}} cell</th>
+        <th role="none" class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
+        <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
+        <td role="none" class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
+        <td role="none" class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
+        <td role="none" class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
+                cell.execution_count)}}</td>
+        <td role="none" class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
+        <td role="none" class="nb-toolbar">{{cell_form(loop.index)}}</td>
+        <td role="none" class="nb-loc">{{loc(cell)}}</td>
 </tr>
 {% endmacro %}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -3,9 +3,8 @@
 {% block body_header %}
 {{super()}}
 <form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label">
-    <button aria-controls="nb-visibility-panel" onclick="openDialog(this)">toggle <span
+    <button aria-controls="nb-visibility-panel" onclick="openDialog()">toggle <span
             id="nb-visibility-label">visibility</span></button>
-
 </form>
 {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
 <dialog id="nb-visibility-panel">

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -1,6 +1,4 @@
 {%- extends 'semantic-forms/base.html.j2' -%}
-{% set title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
-
 
 {% block body_header %}
 {{super()}}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -202,15 +202,15 @@
         aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
         data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
         data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
-        <th role="none" class="nb-label" scope="row">{{cell.cell_type}} cell</th>
-        <th role="none" class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
-        <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
-        <td role="none" class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
-        <td role="none" class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
-        <td role="none" class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
+        <th class="nb-label" scope="row">{{cell.cell_type}} cell</th>
+        <th class="nb-index" scope="row">{{cell_anchor(loop.index)}}</th>
+        <td class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
+        <td class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
+        <td class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
+        <td class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
                 cell.execution_count)}}</td>
-        <td role="none" class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
-        <td role="none" class="nb-toolbar">{{cell_form(loop.index)}}</td>
-        <td role="none" class="nb-loc">{{loc(cell)}}</td>
+        <td class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
+        <td class="nb-toolbar">{{cell_form(loop.index)}}</td>
+        <td class="nb-loc">{{loc(cell)}}</td>
 </tr>
 {% endmacro %}

--- a/nbconvert_html5/templates/semantic-forms/table.html.j2
+++ b/nbconvert_html5/templates/semantic-forms/table.html.j2
@@ -2,208 +2,194 @@
 
 {% block body_header %}
 {{super()}}
+<form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label">
+    <button aria-controls="nb-visibility-panel" onclick="openDialog(this)">toggle <span
+            id="nb-visibility-label">visibility</span></button>
+
+</form>
+{# the table element has the most permissive accessibility semantics of the ARIA specification. #}
+<dialog id="nb-visibility-panel">
+    <form>
+        <button formmethod="dialog">Close</button>
+    </form>
+    <table aria-labelledby="nb-visibility-label" role="grid">
+        <tbody>
+            {# the table head is used to provide controls #}
+            {# it hints at a configurable pattern for showing different features. #}
+            {# there should be controls for each cell type here, and cell types can be
+            added. #}
+            <tr>
+                <td id="nb-cell-label">cell</td>
+                <td id="nb-index-label">index</td>
+                <td id="nb-execution_count-label">execution_count</td>
+                <td id="nb-cell_type-label">cell_type</td>
+                <td id="nb-source-label">source</td>
+                <td id="nb-output-label">output</td>
+                <td id="nb-metadata-label">metadata</td>
+                <td id="nb-toolbar-label">toolbar</td>
+                <td id="nb-loc-label"><abbr title="lines of code">loc</abbr>
+                </td>
+            </tr>
+            <tr class="all">
+                <td>all</td>
+                <td><input form="nb-visibility" aria-labelledby="nb-index-label nb-visibility-label" name="anchor"
+                        type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-execution_count-label nb-visibility-label"
+                        name="execution_count" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-cell_type-label nb-visibility-label"
+                        name="cell_type" type="checkbox">
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-source-label nb-visibility-label" name="source"
+                        type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-output-label nb-visibility-label" name="output"
+                        type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-metadata-label nb-visibility-label" name="metadata"
+                        type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-toolbar-label nb-visibility-label" name="toolbar"
+                        type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-loc-label nb-visibility-label" name="loc"
+                        type="checkbox">
+                </td>
+            </tr>
+            <tr class="code">
+                <td id="nb-code-label">code</td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-index-label nb-visibility-label"
+                        name="anchor" type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility"
+                        aria-labelledby="nb-code-label nb-execution_count-label nb-visibility-label"
+                        name="execution_count" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-cell_type-label nb-visibility-label"
+                        name="cell_type" type="checkbox">
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-source-label nb-visibility-label"
+                        name="source" type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-output-label nb-visibility-label"
+                        name="output" type="checkbox" checked>
+                </td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-metadata-label nb-visibility-label"
+                        name="metadata" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-toolbar-label nb-visibility-label"
+                        name="toolbar" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-code-label nb-loc-label nb-visibility-label"
+                        name="loc" type="checkbox">
+                </td>
+            </tr>
+            <tr class="markdown">
+                <td id="nb-md-label">markdown</td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-index-label nb-visibility-label"
+                        name="anchor" type="checkbox" checked></td>
+                <td><input form="nb-visibility"
+                        aria-labelledby="nb-md-label nb-execution_count-label nb-visibility-label"
+                        name="execution_count" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-cell_type-label nb-visibility-label"
+                        name="cell_type" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-source-label nb-visibility-label"
+                        name="source" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-output-label nb-visibility-label"
+                        name="output" type="checkbox" checked></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-metadata-label nb-visibility-label"
+                        name="metadata" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-toolbar-label nb-visibility-label"
+                        name="toolbar" type="checkbox"></td>
+                <td><input form="nb-visibility" aria-labelledby="nb-md-label nb-loc-label nb-visibility-label"
+                        name="toolbar" type="checkbox"></td>
+            </tr>
+            <tr class="nb-column-descriptions">
+                <td id="nb-description-label">description</td>
+
+                <td>
+                    <p id="nb-index-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-execution_count-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-cell_type-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-source-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-output-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-metadata-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-toolbar-desc"></p>
+                </td>
+                <td>
+                    <p id="nb-loc-desc">significant lines of code in the cell source
+                    </p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</dialog>
 <fieldset name="cells" form="notebook" role="presentation" disabled>
-        {# the fieldset allows formal access to `document.forms["notebook"].elements["cells"]` #}
-        <legend aria-hidden="true" id="nb-cells-label">cells</legend>
+    {# the fieldset allows formal access to `document.forms["notebook"].elements["cells"]` #}
+    <legend aria-hidden="true" id="nb-cells-label">cells</legend>
 
-        {# the most consistent implementation would connect the input visibility to a form #}
-        <form name="visibility" id="nb-visibility" aria-labelledby="nb-visibility-label">
-                <button>toggle <span id="nb-visibility-label">visibility</span></button>
+    {# the most consistent implementation would connect the input visibility to a form #}
+    <table id="cells" role="presentation">
+        <tbody role="list">
+            {# the table caption is removed because testing on VoiceOver iOS encountered
+            https://developer.apple.com/forums/thread/679841
 
-                {# the table element has the most permissive accessibility semantics of the ARIA specification. #}
-                <table aria-labelledby="nb-visibility-label" role="grid" hidden>
-                        <tbody>
-                                {# the table head is used to provide controls #}
-                                {# it hints at a configurable pattern for showing different features. #}
-                                {# there should be controls for each cell type here, and cell types can be added. #}
-                                <tr>
-                                        <td id="nb-cell-label">cell</td>
-                                        <td id="nb-index-label">index</td>
-                                        <td id="nb-execution_count-label">execution_count</td>
-                                        <td id="nb-cell_type-label">cell_type</td>
-                                        <td id="nb-source-label">source</td>
-                                        <td id="nb-output-label">output</td>
-                                        <td id="nb-metadata-label">metadata</td>
-                                        <td id="nb-toolbar-label">toolbar</td>
-                                        <td id="nb-loc-label"><abbr title="lines of code">loc</abbr>
-                                        </td>
-                                </tr>
-                                <tr class="all">
-                                        <td>all</td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-index-label nb-visibility-label"
-                                                        name="anchor" type="checkbox" checked>
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-execution_count-label nb-visibility-label"
-                                                        name="execution_count" type="checkbox" checked></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-cell_type-label nb-visibility-label"
-                                                        name="cell_type" type="checkbox">
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-source-label nb-visibility-label"
-                                                        name="source" type="checkbox" checked>
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-output-label nb-visibility-label"
-                                                        name="output" type="checkbox" checked>
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-metadata-label nb-visibility-label"
-                                                        name="metadata" type="checkbox"></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-toolbar-label nb-visibility-label"
-                                                        name="toolbar" type="checkbox"></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-loc-label nb-visibility-label" name="loc"
-                                                        type="checkbox">
-                                        </td>
-                                </tr>
-                                <tr class="code">
-                                        <td id="nb-code-label">code</td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-index-label nb-visibility-label"
-                                                        name="anchor" type="checkbox" checked>
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-execution_count-label nb-visibility-label"
-                                                        name="execution_count" type="checkbox" checked></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-cell_type-label nb-visibility-label"
-                                                        name="cell_type" type="checkbox">
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-source-label nb-visibility-label"
-                                                        name="source" type="checkbox" checked>
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-output-label nb-visibility-label"
-                                                        name="output" type="checkbox" checked>
-                                        </td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-metadata-label nb-visibility-label"
-                                                        name="metadata" type="checkbox"></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-toolbar-label nb-visibility-label"
-                                                        name="toolbar" type="checkbox"></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-code-label nb-loc-label nb-visibility-label"
-                                                        name="loc" type="checkbox">
-                                        </td>
-                                </tr>
-                                <tr class="markdown">
-                                        <td id="nb-md-label">markdown</td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-index-label nb-visibility-label"
-                                                        name="anchor" type="checkbox" checked></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-execution_count-label nb-visibility-label"
-                                                        name="execution_count" type="checkbox" checked></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-cell_type-label nb-visibility-label"
-                                                        name="cell_type" type="checkbox"></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-source-label nb-visibility-label"
-                                                        name="source" type="checkbox" checked></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-output-label nb-visibility-label"
-                                                        name="output" type="checkbox" checked></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-metadata-label nb-visibility-label"
-                                                        name="metadata" type="checkbox"></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-toolbar-label nb-visibility-label"
-                                                        name="toolbar" type="checkbox"></td>
-                                        <td><input form="nb-visibility"
-                                                        aria-labelledby="nb-md-label nb-loc-label nb-visibility-label"
-                                                        name="toolbar" type="checkbox"></td>
-                                </tr>
-                                <tr class="nb-column-descriptions">
-                                        <td id="nb-description-label">description</td>
+            the best course of action is to remove the caption and provide label support with aria.
+            we wont use captions on any tables for this reason. #}
+            {# <caption hidden>contents</caption> #}
+            {% endblock body_header %}
 
-                                        <td>
-                                                <p id="nb-index-desc"></p>
-                                        </td>
-                                        <td>
-                                                <p id="nb-execution_count-desc"></p>
-                                        </td>
-                                        <td>
-                                                <p id="nb-cell_type-desc"></p>
-                                        </td>
-                                        <td>
-                                                <p id="nb-source-desc"></p>
-                                        </td>
-                                        <td>
-                                                <p id="nb-output-desc"></p>
-                                        </td>
-                                        <td>
-                                                <p id="nb-metadata-desc"></p>
-                                        </td>
-                                        <td>
-                                                <p id="nb-toolbar-desc"></p>
-                                        </td>
-                                        <td>
-                                                <p id="nb-loc-desc">significant lines of code in the cell source</p>
-                                        </td>
-                                </tr>
-                        </tbody>
-                </table>
-        </form>
-        <table id="cells" role="presentation">
-                <tbody role="list">
-                        {# the table caption is removed because testing on VoiceOver iOS encountered
-                        https://developer.apple.com/forums/thread/679841
+            {% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}
 
-                        the best course of action is to remove the caption and provide label support with aria.
-                        we wont use captions on any tables for this reason. #}
-                        {# <caption hidden>contents</caption> #}
-                        {% endblock body_header %}
+            {% block body_footer %}
+        </tbody>
+    </table>
+    <table class="nb-cells-footer" hidden>
+        <tbody>
+            {# needs a header row #}
+            <tr class="total">
+                <th scope="row">all cells</th>
+                <th scope="row">count</th>
+                <td class="nb-ordered">{{ordered(nb)}}</td>
+                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                <td class="nb-source"></td>
+                <td class="nb-outputs">{{count_outputs(nb)}}</td>
+                <td class="nb-toolbar"></td>
+                <td class="nb-metadata">{# list keys #}</td>
+                <td class="nb-loc">{{count_loc(nb)}}</td>
 
-                        {% block any_cell %}{{cell_row(cell, loop)}}{% endblock any_cell %}
-
-                        {% block body_footer %}
-                </tbody>
-        </table>
-        <table class="nb-cells-footer" hidden>
-                <tbody>
-                        {# needs a header row #}
-                        <tr class="total">
-                                <th scope="row">all cells</th>
-                                <th scope="row">count</th>
-                                <td class="nb-ordered">{{ordered(nb)}}</td>
-                                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-                                <td class="nb-source"></td>
-                                <td class="nb-outputs">{{count_outputs(nb)}}</td>
-                                <td class="nb-toolbar"></td>
-                                <td class="nb-metadata">{# list keys #}</td>
-                                <td class="nb-loc">{{count_loc(nb)}}</td>
-
-                        </tr>
-                        <tr class="code">
-                                <th scope="row">cpde cells</th>
-                                <th scope="row">count</th>
-                                <td class="nb-ordered">{{ordered(nb)}}</td>
-                                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-                                <td class="nb-source"></td>
-                                <td class="nb-outputs">{{count_outputs(nb)}}</td>
-                                <td class="nb-toolbar"></td>
-                                <td class="nb-metadata">{# list keys #}</td>
-                                <td class="nb-loc">{{count_loc(nb)}}</td>
-                        </tr>
-                        <tr class="markdown">
-                                <th scope="row">markdown cells</th>
-                                <th scope="row">count</th>
-                                <td class="nb-ordered"></td>
-                                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-                                <td class="nb-source"></td>
-                                <td class="nb-outputs"></td>
-                                <td class="nb-toolbar"></td>
-                                <td class="nb-metadata">{# list keys #}</td>
-                                <td class="nb-loc">{{count_loc(nb)}}</td>
-                        </tr>
-                </tbody>
-        </table>
+            </tr>
+            <tr class="code">
+                <th scope="row">cpde cells</th>
+                <th scope="row">count</th>
+                <td class="nb-ordered">{{ordered(nb)}}</td>
+                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                <td class="nb-source"></td>
+                <td class="nb-outputs">{{count_outputs(nb)}}</td>
+                <td class="nb-toolbar"></td>
+                <td class="nb-metadata">{# list keys #}</td>
+                <td class="nb-loc">{{count_loc(nb)}}</td>
+            </tr>
+            <tr class="markdown">
+                <th scope="row">markdown cells</th>
+                <th scope="row">count</th>
+                <td class="nb-ordered"></td>
+                <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
+                <td class="nb-source"></td>
+                <td class="nb-outputs"></td>
+                <td class="nb-toolbar"></td>
+                <td class="nb-metadata">{# list keys #}</td>
+                <td class="nb-loc">{{count_loc(nb)}}</td>
+            </tr>
+        </tbody>
+    </table>
 </fieldset>
 {{super()}}
 {% endblock body_footer %}
@@ -212,17 +198,17 @@
 
 {% macro cell_row(cell, loop) %}
 <tr role="listitem" class="cell {{cell.cell_type}}"
-        aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
-        data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
-        data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
-        <td class="nb-index">{{cell_anchor(loop.index)}}</td>
-        <td class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
-        <td class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
-        <td class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
-        <td class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
-                cell.execution_count)}}</td>
-        <td class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
-        <td class="nb-toolbar">{{cell_form(loop.index)}}</td>
-        <td class="nb-loc">{{loc(cell)}}</td>
+    aria-labelledby="nb-def-cell {{loop.index}} cell-{{loop.index}}-cell_type"
+    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
+    data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
+    <td class="nb-index">{{cell_anchor(loop.index)}}</td>
+    <td class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}</td>
+    <td class="nb-cell_type">{{cell_cell_type(loop.index, cell.cell_type)}}</td>
+    <td class="nb-source">{{cell_source(loop.index, cell.source, cell.execution_count)}}</td>
+    <td class="nb-outputs">{{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type,
+        cell.execution_count)}}</td>
+    <td class="nb-metadata">{{cell_metadata(loop.index, cell.metadata)}}</td>
+    <td class="nb-toolbar">{{cell_form(loop.index)}}</td>
+    <td class="nb-loc">{{loc(cell)}}</td>
 </tr>
 {% endmacro %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,6 @@ configurations = [
     "tests/configurations/sections.py",
     "tests/configurations/smol.py",
     "tests/configurations/ol.py",
-    "tests/configurations/ul.py",
     "tests/configurations/feed.py",
     # "tests/configurations/notebook-list.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,14 @@ classifiers = [
     "Programming Language :: Python",
     "License :: OSI Approved :: BSD License",
 ]
-dependencies = ["nbconvert", "accessible-pygments", "pydantic < 2", "IPython", "markdown-it-py[plugins,linkify]", ]
+dependencies = [
+    "nbconvert",
+    "accessible-pygments",
+    "pydantic < 2",
+    "IPython",
+    "markdown-it-py[plugins,linkify]",
+    "python-slugify",
+]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "IPython",
     "markdown-it-py[plugins,linkify]",
     "python-slugify",
+    "html5lib"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ configurations = [
     "tests/configurations/smol.py",
     "tests/configurations/ol.py",
     "tests/configurations/feed.py",
+    "tests/configurations/main.py",
     # "tests/configurations/notebook-list.py",
 ]
 

--- a/tests/configurations/main.py
+++ b/tests/configurations/main.py
@@ -1,0 +1,6 @@
+"""export notebooks as a main region with cell landmarks"""
+
+c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
+c.NbConvertApp.export_format = "html5"
+c.CSSHTMLHeaderPreprocessor.style = "default"
+c.TemplateExporter.template_file = "semantic-forms/main.html.j2"

--- a/tests/configurations/table-default.py
+++ b/tests/configurations/table-default.py
@@ -3,4 +3,4 @@
 c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
 c.NbConvertApp.export_format = "html5"
 c.CSSHTMLHeaderPreprocessor.style = "default"
-c.TemplateExporter.template_file = "semantic-forms/main.html.j2"
+c.TemplateExporter.template_file = "semantic-forms/table.html.j2"

--- a/tests/configurations/table-default.py
+++ b/tests/configurations/table-default.py
@@ -3,3 +3,4 @@
 c.CSSHTMLHeaderPreprocessor.style = "github-light-colorblind"
 c.NbConvertApp.export_format = "html5"
 c.CSSHTMLHeaderPreprocessor.style = "default"
+c.TemplateExporter.template_file = "semantic-forms/main.html.j2"


### PR DESCRIPTION
this pull request represent cells as a table body, and in action they are a layout table. layout tables should now have a thead, but tabular data should. in practice, we have a `thead` as a widget for choosing cell visibility and `tfoot` as a region to describe the notebook statistics. these two new features as critical content that create richer to `aria-labelledby` `aria-describedby` `aria-details` attributes.

we also introduce activity log regions that capture changes and provide `aria-live` announcements to screen reader users. the activity logs need to be placed in each `dialog`; the `dialog` destroys the accessibility tree and does not expose any non-`dialog` aria live changes. currently the announcements confirm configuration changes. they will be used for `kernel started` `cell completed` messages.