### PR TITLE
pytest-html, continue on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
           pip install -e.
           doit copy
       - name: test with pytest
+        # always build the docs to see what the new versions look like.
+        continue-on-error: true
         run: |
           # the smoke generate html assets that are used in the accessibility testing.
           # we run this script to generate assets and test the nbconvert-a11y module.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,16 @@ jobs:
           npm install vnu-jar axe-core
           pip install -e.
           doit copy
-      - name: test with pytest
-        # always build the docs to see what the new versions look like.
-        continue-on-error: true
+      - name: smoke test
         run: |
           # the smoke generate html assets that are used in the accessibility testing.
           # we run this script to generate assets and test the nbconvert-a11y module.
+          # failures here will stop any docs builds
           pytest tests/test_smoke.py
+      - name: a11y tests
+        # always build the docs to see what the new versions look like.
+        continue-on-error: true
+        run: |          
           pytest --deselect tests/test_smoke.py
       - name: mkdocs
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
     "pytest-xdist",
     "pytest-sugar",
     "pytest-playwright",
+    "pytest-html",
     "matplotlib",
     "numpy",
     "ipywidgets",
@@ -88,7 +89,7 @@ run = "pytest"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-vvv -pno:importnb -n auto"
+addopts = "-vvv -pno:importnb -n auto --self-contained-html --html=tests/exports/pytest/report.html"
 testpaths = ["tests", "test_playwright.py"]
 norecursedirs = ["tests/exports", "tests/notebooks", "*checkpoints"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ test = [
     "pytest-xdist",
     "pytest-sugar",
     "pytest-playwright",
-    "nbval",
     "matplotlib",
     "numpy",
     "ipywidgets",
@@ -89,7 +88,7 @@ run = "pytest"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-vvv --nbval --nbval-current-env -pno:importnb -n auto --nbval-sanitize-with=sanitize.cfg"
+addopts = "-vvv -pno:importnb -n auto"
 testpaths = ["tests", "test_playwright.py"]
 norecursedirs = ["tests/exports", "tests/notebooks", "*checkpoints"]
 

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip
   - pip:
     - pytest-playwright
-    - nbval
+    - pytest-html
     - accessible-pygments
     - requests-cache
     - markdown-it-py[plugins,linkify]

--- a/tests/test_a11y.py
+++ b/tests/test_a11y.py
@@ -1,0 +1,60 @@
+"""specific ui and accessibility tests for the custom a11y template"""
+
+
+from pytest import fixture, mark, param
+
+from tests.test_smoke import CONFIGURATIONS, NOTEBOOKS, get_target_html
+
+from nbconvert_html5.pytest_axe import inject_axe, run_axe_test
+
+NEEDS_WORK = "state needs work"
+
+
+@fixture(
+    params=[
+        param(
+            get_target_html(CONFIGURATIONS / "a11y.py", NOTEBOOKS / "lorenz-executed.ipynb"),
+            id="executed-a11y",
+        )
+    ],
+)
+def test_page(request, page):
+    # https://github.com/microsoft/playwright-pytest/issues/73
+    page.goto(request.param.absolute().as_uri())
+    inject_axe(page)
+    yield page
+    page.close()
+
+
+@mark.parametrize(
+    "dialog",
+    [
+        "[aria-controls=nb-settings]",
+        "[aria-controls=nb-help]",
+        "[aria-controls=nb-metadata]",
+        "[aria-controls=nb-audit]",
+        param("[aria-controls=nb-expanded-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
+        param("[aria-controls=nb-visibility-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
+        # param("nada", marks=mark.xfail(reason="no selector")),
+        # failing selectors timeout and slow down tests.
+    ],
+)
+def test_dialogs(test_page, dialog):
+    """test the controls in dialogs"""
+    # dialogs are not tested in the baseline axe test. they need to be active to test.
+    # these tests activate the dialogs to assess their accessibility with the active dialogs.
+    test_page.click(dialog)
+    run_axe_test(test_page).raises()
+
+
+SNIPPET_FONT_SIZE = (
+    """window.getComputedStyle(document.querySelector("body")).getPropertyValue("font-size")"""
+)
+
+
+def test_settings_font_size(test_page):
+    """test that the settings make their expected changes"""
+    assert test_page.evaluate(SNIPPET_FONT_SIZE) == "16px", "the default font size is unexpected"
+    test_page.click("[aria-controls=nb-settings]")
+    test_page.locator("#nb-table-font-size-group").select_option("xx-large")
+    assert test_page.evaluate(SNIPPET_FONT_SIZE) == "32px", "font size not changed"

--- a/tests/test_axe.py
+++ b/tests/test_axe.py
@@ -7,12 +7,8 @@
 from logging import getLogger
 from pathlib import Path
 
-import exceptiongroup
-from nbconvert_html5.pytest_axe import inject_axe, run_axe_test
-from test_nbconvert_html5 import exporter
 
-
-from pytest import fixture, mark, param, xfail
+from pytest import mark, param
 
 from tests.test_smoke import CONFIGURATIONS, NOTEBOOKS, SKIPCI, get_target_html
 
@@ -26,7 +22,6 @@ AUDIT = EXPORTS / "audit"
 # ignore mathjax at the moment. we might be able to turne mathjax to have better
 # accessibility. https://github.com/Iota-School/notebooks-for-all/issues/81
 MATHJAX = "[id^=MathJax]"
-NEEDS_WORK = "state needs work"
 
 
 config_notebooks_aa = mark.parametrize(
@@ -87,63 +82,3 @@ def test_axe_aaa(axe, config, notebook):
     target = get_target_html(config, notebook)
     audit = AUDIT / target.with_suffix(".json").name
     axe(Path.as_uri(target), axe_config=axe_config_aaa).dump(audit).raises()
-
-
-config_notebooks_dialog = mark.parametrize(
-    "config,notebook",
-    [
-        param(
-            (CONFIGURATIONS / (a := "a11y")).with_suffix(".py"),
-            (NOTEBOOKS / (b := "lorenz-executed")).with_suffix(".ipynb"),
-            id="-".join(
-                (b, a),
-            ),
-        )
-    ],
-)
-
-
-@fixture(scope="function")
-def axe_page(page):
-    def go(url):
-        page.goto(url)
-        inject_axe(page)
-        return page
-
-    return go
-
-
-@config_notebooks_dialog
-@mark.parametrize(
-    "dialog",
-    [
-        "[aria-controls=nb-settings]",
-        "[aria-controls=nb-help]",
-        "[aria-controls=nb-metadata]",
-        "[aria-controls=nb-audit]",
-        param("[aria-controls=nb-expanded-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
-        param("[aria-controls=nb-visibility-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
-        param("nada", marks=mark.xfail(reason="no selector")),
-    ],
-)
-def test_dialogs(axe_page, config, notebook, dialog):
-    """test the controls in dialogs"""
-    # dialogs are not tested in the baseline axe test. they need to be active to test.
-    # these tests activate the dialogs to assess their accessibility with the active dialogs.
-
-    page = axe_page(get_target_html(config, notebook).absolute().as_uri())
-    page.click(dialog)
-    run_axe_test(page).raises()
-
-
-@config_notebooks_dialog
-def test_settings_font_size(axe_page, config, notebook):
-    """test that the settings make their expected changes"""
-    page = axe_page(get_target_html(config, notebook).absolute().as_uri())
-    font_size = lambda: page.evaluate(
-        """window.getComputedStyle(document.querySelector("body")).getPropertyValue("font-size")"""
-    )
-    assert font_size() == "16px"
-    page.click("[aria-controls=nb-settings]")
-    page.locator("#nb-table-font-size-group").select_option("xx-large")
-    assert font_size() == "32px", "font size not changed"


### PR DESCRIPTION
add test reports to pytest with `pytest-html` and continue on `pytest` failure on CI so that docs will always get built. actually the smoke test should break the docs too.